### PR TITLE
Fix: setup should not init '$' REPL if running with basic REPL

### DIFF
--- a/src/setup.jl
+++ b/src/setup.jl
@@ -194,7 +194,7 @@ function __init__()
         # R gui eventloop
         isinteractive() && rgui_init()
         # R REPL mode
-        isdefined(Base, :active_repl) && isinteractive() && repl_init(Base.active_repl)
+        isdefined(Base, :active_repl) && isinteractive() && typeof(Base.active_repl) != Base.REPL.BasicREPL && repl_init(Base.active_repl)
     end
 
     # # IJulia hooks


### PR DESCRIPTION
This prevents activation of REPL '$' symbol if julia is being run in a dumb terminal.  This happens if it is run e.g. within emacs (for example. usng julia-mode and ESS)