### PR TITLE
Convert Date and DateTime to/from R

### DIFF
--- a/src/convert-base.jl
+++ b/src/convert-base.jl
@@ -140,6 +140,35 @@ for (J,S) in ((:Integer,:IntSxp),
     end
 end
 
+# Date and DateTime
+function sexp(d::Date)
+    res = sexp(RealSxp, convert(Float64, d - Dates.Day(719163)))
+    setclass!(res, sexp("Date"))
+    res
+end
+function sexp(a::AbstractArray{Date})
+    res = sexp(RealSxp, convert(AbstractArray{Float64}, a - Dates.Day(719163)))
+    setclass!(res, sexp("Date"))
+    res
+end
+function sexp(d::DateTime)
+    res = sexp(RealSxp, convert(Float64, d - Dates.Day(719163)) / 1000)
+    setclass!(res, sexp(["POSIXct", "POSIXt"]))
+    setattrib!(res, "tzone", sexp("UTC"))
+    res
+end
+function sexp(a::AbstractArray{DateTime})
+    res = sexp(RealSxp, convert(AbstractArray{Float64}, a - Dates.Day(719163)) / 1000)
+    setclass!(res, sexp(["POSIXct", "POSIXt"]))
+    setattrib!(res, "tzone", sexp("UTC"))
+    res
+end
+rcopy(::Type{Date}, s::RealSxpPtr) = rcopy(Date, s[1])
+rcopy(::Type{DateTime}, s::RealSxpPtr) = rcopy(DateTime, s[1])
+
+rcopy(::Type{Date}, x::Float64) = convert(Date, x) + Dates.Day(719163)
+rcopy(::Type{DateTime}, x::Float64) = convert(DateTime, x*1000) + Dates.Day(719163)
+
 
 # Handle LglSxp seperately
 sexp(::Type{LglSxp},v::Union{Bool,Cint}) =

--- a/src/convert-data.jl
+++ b/src/convert-data.jl
@@ -14,7 +14,13 @@ function rcopy{S<:StrSxp}(::Type{Nullable}, s::Ptr{S})
 end
 
 function rcopy{T,S<:VectorSxp}(::Type{NullableArray{T}}, s::Ptr{S})
-    NullableArray(rcopy(Array{T},s), isna(s))
+    if T == Date || T == DateTime
+        # Can not convert NaN to Date or DateTime which are internally stored as Int
+        value = T[isna(x) ? convert(T, 0.0) : rcopy(T, x) for x in s]
+        NullableArray(value, isna(s))
+    else
+        NullableArray(rcopy(Array{T},s), isna(s))
+    end
 end
 function rcopy{S<:VectorSxp}(::Type{NullableArray}, s::Ptr{S})
     NullableArray(rcopy(Array,s), isna(s))

--- a/src/convert-default.jl
+++ b/src/convert-default.jl
@@ -16,12 +16,22 @@ function rcopy(s::StrSxpPtr)
     end
 end
 function rcopy(s::RealSxpPtr)
+    T = Float64
+    classPtr = sexp(getclass(s))
+    if typeof(classPtr) == StrSxpPtr
+        class = rcopy(Vector{String}, classPtr)
+        if  "Date" in class
+            T = Date
+        elseif "POSIXct" in class
+            T = DateTime
+        end
+    end
     if anyna(s)
-        rcopy(NullableArray{Float64},s)
+        rcopy(NullableArray{T},s)
     elseif length(s) == 1
-        rcopy(Float64,s)
+        rcopy(T,s)
     else
-        rcopy(Array{Float64},s)
+        rcopy(Array{T},s)
     end
 end
 function rcopy(s::CplxSxpPtr)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -168,6 +168,73 @@ r = RObject(a)
 @test r[3] === convert(Float64,a[3])
 @test r[2,3,1,2] === convert(Float64,a[2,3,1,2])
 
+# date
+s = "2012-12-12"
+d = Date(s)
+r = RObject(d)
+@test isa(r,RObject{RealSxp})
+@test rcopy(getclass(r)) == "Date"
+@test length(r) == 1
+@test size(r) == (1,)
+@test rcopy(r) === d
+@test rcopy(R"as.Date($s)") == d
+@test rcopy(R"identical(as.Date($s), $d)")
+
+s = ["2001-01-01", "1111-11-11", "2012-12-12"]
+d = Date.(s)
+r = RObject(d)
+@test isa(r,RObject{RealSxp})
+@test rcopy(getclass(r)) == "Date"
+@test length(r) == length(d)
+@test size(r) == size(d)
+@test rcopy(r) == d
+@test rcopy(R"as.Date($s)") == d
+@test rcopy(R"identical(as.Date($s), $d)")
+
+d = Date[]
+r = RObject(d)
+@test isa(r,RObject{RealSxp})
+@test rcopy(getclass(r)) == "Date"
+@test length(r) == length(d)
+@test size(r) == size(d)
+@test rcopy(r) == d
+@test rcopy("as.Date(character(0))") == Date[]
+
+# dateTime
+s = "2012-12-12T12:12:12"
+d = DateTime(s)
+r = RObject(d)
+@test isa(r,RObject{RealSxp})
+@test rcopy(getclass(r)) == ["POSIXct", "POSIXt"]
+@test rcopy(getattrib(r, "tzone")) == "UTC"
+@test length(r) == 1
+@test size(r) == (1,)
+@test rcopy(r) === d
+@test rcopy(R"as.POSIXct($s, 'UTC', '%Y-%m-%dT%H:%M:%S')") == d
+@test rcopy(R"identical(as.character($d, '%Y-%m-%dT%H:%M:%S'), $s)")
+
+s = ["2001-01-01T01:01:01", "1111-11-11T11:11:00", "2012-12-12T12:12:12"]
+d = DateTime.(s)
+r = RObject(d)
+@test isa(r,RObject{RealSxp})
+@test rcopy(getclass(r)) == ["POSIXct", "POSIXt"]
+@test rcopy(getattrib(r, "tzone")) == "UTC"
+@test length(r) == length(d)
+@test size(r) == size(d)
+@test rcopy(r) == d
+@test rcopy(R"as.POSIXct($s, 'UTC', '%Y-%m-%dT%H:%M:%S')") == d
+@test rcopy(R"identical(as.character($d, '%Y-%m-%dT%H:%M:%S'), $s)")
+
+d = DateTime[]
+r = RObject(d)
+@test isa(r,RObject{RealSxp})
+@test rcopy(getclass(r)) == ["POSIXct", "POSIXt"]
+@test rcopy(getattrib(r, "tzone")) == "UTC"
+@test length(r) == length(d)
+@test size(r) == size(d)
+@test rcopy(r) == d
+@test rcopy("as.POSIXct(character(0))") == Date[]
+
 # complex
 x = 7.0-2.0*im
 r = RObject(x)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -1,3 +1,6 @@
+using NullableArrays
+
+
 # strings
 x = "ppzz!#"
 r = RObject(x)
@@ -200,6 +203,31 @@ r = RObject(d)
 @test rcopy(r) == d
 @test rcopy("as.Date(character(0))") == Date[]
 
+# nullable date
+s = NullableArray(["0001-01-01", "2012-12-12"], [true, false])
+d = NullableArray(Date.(s.values), s.isnull)
+r = RObject(d)
+@test isa(r,RObject{RealSxp})
+@test rcopy(getclass(r)) == "Date"
+@test length(r) == length(d)
+@test size(r) == size(d)
+@test rcopy(r).isnull == d.isnull
+@test rcopy(r).values[!d.isnull] == d.values[!d.isnull]
+@test rcopy(R"identical(as.Date($s), $d)")
+@test rcopy(R"identical(as.character($d), $s)")
+
+s = NullableArray(["0001-01-01"], [true])
+d = NullableArray(Date.(s.values), s.isnull)
+r = RObject(d)
+@test isa(r,RObject{RealSxp})
+@test rcopy(getclass(r)) == "Date"
+@test length(r) == length(d)
+@test size(r) == size(d)
+@test all(rcopy(r).isnull)
+@test rcopy(R"identical(as.Date(NA), $d)")
+@test rcopy(R"identical(as.character(NA), $s)")
+
+
 # dateTime
 s = "2012-12-12T12:12:12"
 d = DateTime(s)
@@ -234,6 +262,33 @@ r = RObject(d)
 @test size(r) == size(d)
 @test rcopy(r) == d
 @test rcopy("as.POSIXct(character(0))") == Date[]
+
+# nullable dateTime
+s = NullableArray(["0001-01-01", "2012-12-12T12:12:12"], [true, false])
+d = NullableArray(DateTime.(s.values), s.isnull)
+r = RObject(d)
+@test isa(r,RObject{RealSxp})
+@test rcopy(getclass(r)) == ["POSIXct", "POSIXt"]
+@test rcopy(getattrib(r, "tzone")) == "UTC"
+@test length(r) == length(d)
+@test size(r) == size(d)
+@test rcopy(r).isnull == d.isnull
+@test rcopy(r).values[!d.isnull] == d.values[!d.isnull]
+@test rcopy(R"identical(as.POSIXct($s, 'UTC', '%Y-%m-%dT%H:%M:%S'), $d)")
+@test rcopy(R"identical(as.character($d, '%Y-%m-%dT%H:%M:%S'), $s)")
+
+s = NullableArray(["0001-01-01"], [true])
+d = NullableArray(DateTime.(s.values), s.isnull)
+r = RObject(d)
+@test isa(r,RObject{RealSxp})
+@test rcopy(getclass(r)) == ["POSIXct", "POSIXt"]
+@test rcopy(getattrib(r, "tzone")) == "UTC"
+@test length(r) == length(d)
+@test size(r) == size(d)
+@test all(rcopy(r).isnull)
+@test rcopy(R"identical(as.POSIXct(NA_character_, 'UTC'), $d)")
+@test rcopy(R"identical(as.character(NA), $s)")
+
 
 # complex
 x = 7.0-2.0*im


### PR DESCRIPTION
Support `Data` and `DateTime` types by converting from/to R's `Date` and `POSIXct` classes.

```
julia> using RCall

julia> d = Dates.today()
2017-01-11

julia> tm = now()
2017-01-11T23:14:01.148

julia> R"""
       cat(paste0("Today's date is ", $d ,".\n"))
       cat(paste0("The current timestamp is ", $tm ,".\n"))
       """;
Today's date is 2017-01-11.
The current timestamp is 2017-01-11 23:14:01.

julia> R"""
       d <- as.Date(c("2010-10-10", "2009-09-09"))
       tm <- as.POSIXct(c("1942-04-02 04:42:42", "2020-02-20 20:02:20"), "UTC")
       """;

julia> rcopy("d")
2-element Array{Date,1}:
 2010-10-10
 2009-09-09

julia> rcopy("tm")
2-element Array{DateTime,1}:
 1942-04-02T04:42:42
 2020-02-20T20:02:20
```