### PR TITLE
Add test for using R's lm on SubDataFrame

### DIFF
--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -14,6 +14,7 @@ attenu = rcopy(DataFrame,:attenu)
 @test isa(attenu,DataFrame)
 @test size(attenu) == (182,5)
 @test rcopy(rcall(:dim,RObject(attenu))) == [182,5]
+@test nrow(by(df -> R"lm(data=$df, dist  ~ accel)", attenu, :event)) == 23
 
 dist = attenu[:dist]
 @test isa(dist,Vector{Float64})


### PR DESCRIPTION
Add test for using R's lm() inside DataFrames' by() (SubDataFrame)
This is an indirect test for (i.e.) `RCall.sexp(sub(attenu,1:10))`