### PR TITLE
Fixes error when importing vector of invariant factor to Julia

### DIFF
--- a/src/convert/dataframe.jl
+++ b/src/convert/dataframe.jl
@@ -14,7 +14,7 @@ end
 function rcopy(::Type{PooledDataArray}, s::Ptr{IntSxp})
     isFactor(s) || error("s is not an R factor")
     refs = DataArrays.RefArray([isNA(x) ? zero(Int32) : x for x in s])
-    DataArrays.compact(PooledDataArray(refs,rcopy(getattrib(s,Const.LevelsSymbol))))
+    DataArrays.compact(PooledDataArray(refs, rcopy(Array, getattrib(s,Const.LevelsSymbol))))
 end
 
 function rcopy{T<:AbstractDataFrame}(::Type{T}, s::Ptr{VecSxp}; sanitize::Bool=true)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -146,3 +146,4 @@ iris = rcopy(reval(:iris))
 model =  R"lm(Sepal_Length ~ Sepal_Width,data=$iris)"
 @test rcopy(RCall.getclass(model)) == "lm"
 @test isapprox(rcopy(R"sum($iris$Sepal_Length)"), sum(iris[:Sepal_Length]), rtol=4*eps())
+@test rcopy(R"factor(rep(1,10))") == fill("1",10)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -147,3 +147,4 @@ model =  R"lm(Sepal_Length ~ Sepal_Width,data=$iris)"
 @test rcopy(RCall.getclass(model)) == "lm"
 @test isapprox(rcopy(R"sum($iris$Sepal_Length)"), sum(iris[:Sepal_Length]), rtol=4*eps())
 @test rcopy(R"factor(rep(1,10))") == fill("1",10)
+@test rcopy(R"data.frame(a=rep('test',10), stringsAsFactors = TRUE)")[:a] == fill("test",10)


### PR DESCRIPTION
e.g. rcopy(R"factor(rep(1,10))"). Error due to rcopy(Array,
getattrib(s,Const.LevelsSymbol)) returning string type when importing
factor vector of repeated single level. the string is passed to
PooledDataArray constructor, which expects an array and throws error.
Fixed by enforcing Array type using rcopy(Array, getattribs(...))