### PR TITLE
Add upper bounds on CategoricalArrays 0.2.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,7 +3,7 @@ Nulls 0.1.0
 DataStructures 0.5.0
 DataFrames 0.10
 DataArrays 0.5.0
-CategoricalArrays 0.1.0
+CategoricalArrays 0.1.0 0.2.0
 NullableArrays 0.1.0
 AxisArrays 0.0.6
 NamedArrays 0.5.3


### PR DESCRIPTION
That version broke compatibility with previous releases.

See https://github.com/JuliaLang/METADATA.jl/pull/12040.

We'll have to make a PR soon to port to CategoricalArrays 0.3.