### PR TITLE
move libR detection to Pkg.build, support Conda installation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,4 +6,5 @@ DataArrays 0.7.0
 CategoricalArrays 0.3.0
 AxisArrays 0.0.6
 Compat 0.34.0
+Conda
 @windows WinReg 0.2.0

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,40 +7,48 @@ end
 include("setup.jl")
 
 const depfile = joinpath(dirname(@__FILE__), "deps.jl")
-if isfile(depfile)
-    @eval module DepFile; include($depfile); end
-else
-    @eval module DepFile; Rhome=libR=""; end
-end
 
-if !haskey(ENV,"R_HOME") && isdir(DepFile.Rhome) && validate_libR(DepFile.libR, false)
-    Rhome, libR = DepFile.Rhome, DepFile.libR
-    info("Using previously configured R at $Rhome with libR in $libR.")
-else
-    Rhome = get(ENV, "R_HOME", "")
-    if isempty(Rhome)
-        try Rhome = readchomp(`R RHOME`); end
+try
+    if isfile(depfile)
+        @eval module DepFile; include($depfile); end
+    else
+        @eval module DepFile; Rhome=libR=""; end
     end
-    @static if Compat.Sys.iswindows()
+
+    if !haskey(ENV,"R_HOME") && isdir(DepFile.Rhome) && validate_libR(DepFile.libR, false)
+        Rhome, libR = DepFile.Rhome, DepFile.libR
+        info("Using previously configured R at $Rhome with libR in $libR.")
+    else
+        Rhome = get(ENV, "R_HOME", "")
         if isempty(Rhome)
-            try Rhome = WinReg.querykey(WinReg.HKEY_LOCAL_MACHINE,
-                                        "Software\\R-Core\\R", "InstallPath"); end
+            try Rhome = readchomp(`R RHOME`); end
+        end
+        @static if Compat.Sys.iswindows()
+            if isempty(Rhome)
+                try Rhome = WinReg.querykey(WinReg.HKEY_LOCAL_MACHINE,
+                                            "Software\\R-Core\\R", "InstallPath"); end
+            end
+        end
+        libR = isempty(Rhome) || !isdir(Rhome) ? "" : locate_libR(Rhome, false)
+        if isempty(libR)
+            different = "  To use a different R installation, set the \"R_HOME\" environment variable and re-run Pkg.build(\"RCall\")."
+            info("Installing R via Conda.$different")
+            Conda.add_channel("conda-forge")
+            Conda.add("r-base")
+            Rhome = joinpath(Conda.LIBDIR, "R")
+            libR = locate_libR(Rhome, false)
+            isempty(libR) && error("Conda R installation failed.$different")
+        end
+
+        info("Using R at $Rhome and libR at $libR.")
+        if DepFile.Rhome != Rhome || DepFile.libR != libR
+            open(depfile, "w") do f
+                println(f, "const Rhome = \"", escape_string(Rhome), '"')
+                println(f, "const libR = \"", escape_string(libR), '"')
+            end
         end
     end
-    libR = isempty(Rhome) || !isdir(Rhome) ? "" : locate_libR(Rhome, false)
-    if isempty(libR)
-        different = "  To use a different R installation, set the \"R_HOME\" environment variable and re-run Pkg.build(\"RCall\")."
-        info("Installing R via Conda.$different")
-        Conda.add_channel("conda-forge")
-        Conda.add("r-base")
-        Rhome = joinpath(Conda.LIBDIR, "R")
-        libR = locate_libR(Rhome, false)
-        isempty(libR) && error("Conda R installation failed.$different")
-    end
-
-    info("Using R at $Rhome and libR at $libR.")
-    open(depfile, "w") do f
-        println(f, "const Rhome = \"", escape_string(Rhome), '"')
-        println(f, "const libR = \"", escape_string(libR), '"')
-    end
+catch
+    rm(depfile, force=true) # delete on error
+    rethrow()
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,46 @@
+using Compat
+import Conda
+@static if Compat.Sys.iswindows()
+    import WinReg
+end
+
+include("setup.jl")
+
+const depfile = joinpath(dirname(@__FILE__), "deps.jl")
+if isfile(depfile)
+    @eval module DepFile; include($depfile); end
+else
+    @eval module DepFile; Rhome=libR=""; end
+end
+
+if !haskey(ENV,"R_HOME") && isdir(DepFile.Rhome) && validate_libR(DepFile.libR, false)
+    Rhome, libR = DepFile.Rhome, DepFile.libR
+    info("Using previously configured R at $Rhome with libR in $libR.")
+else
+    Rhome = get(ENV, "R_HOME", "")
+    if isempty(Rhome)
+        try Rhome = readchomp(`R RHOME`); end
+    end
+    @static if Compat.Sys.iswindows()
+        if isempty(Rhome)
+            try Rhome = WinReg.querykey(WinReg.HKEY_LOCAL_MACHINE,
+                                        "Software\\R-Core\\R", "InstallPath"); end
+        end
+    end
+    libR = isempty(Rhome) || !isdir(Rhome) ? "" : locate_libR(Rhome, false)
+    if isempty(libR)
+        different = "  To use a different R installation, set the \"R_HOME\" environment variable and re-run Pkg.build(\"RCall\")."
+        info("Installing R via Conda.$different")
+        Conda.add_channel("conda-forge")
+        Conda.add("r-base")
+        Rhome = joinpath(Conda.LIBDIR, "R")
+        libR = locate_libR(Rhome, false)
+        isempty(libR) && error("Conda R installation failed.$different")
+    end
+
+    info("Using R at $Rhome and libR at $libR.")
+    open(depfile, "w") do f
+        println(f, "const Rhome = \"", escape_string(Rhome), '"')
+        println(f, "const libR = \"", escape_string(libR), '"')
+    end
+end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -33,7 +33,7 @@ try
         if isempty(libR)
             different = "  To use a different R installation, set the \"R_HOME\" environment variable and re-run Pkg.build(\"RCall\")."
             info("Installing R via Conda.$different")
-            Conda.add_channel("conda-forge")
+            Conda.add_channel("r")
             Conda.add("r-base")
             Rhome = joinpath(Conda.LIBDIR, "R")
             libR = locate_libR(Rhome, false)

--- a/deps/setup.jl
+++ b/deps/setup.jl
@@ -1,0 +1,52 @@
+"""
+    validate_libR(libR, raise=true)
+
+Checks that the R library `libR` can be loaded and is satisfies version requirements.
+
+If `raise` is set to `false`, then returns a boolean indicating success rather
+than throwing exceptions.
+"""
+function validate_libR(libR, raise=true)
+    if !isfile(libR)
+        raise || return false
+        error("Could not find library $libR. Make sure that R shared library exists.")
+    end
+    # Issue #143
+    # On linux, sometimes libraries linked from libR (e.g. libRblas.so) won't open unless LD_LIBRARY_PATH is set correctly.
+    libptr = try
+        Libdl.dlopen(libR)
+    catch er
+        raise || return false
+        Base.with_output_color(:red, STDERR) do io
+            print(io, "ERROR: ")
+            showerror(io, er)
+            println(io)
+        end
+        if Compat.Sys.iswindows()
+            error("Try adding $(dirname(libR)) to the \"PATH\" environmental variable and restarting Julia.")
+        else
+            error("Try adding $(dirname(libR)) to the \"LD_LIBRARY_PATH\" environmental variable and restarting Julia.")
+        end
+    end
+    # R_tryCatchError is only available on v3.4.0 or later.
+    if Libdl.dlsym_e(libptr, "R_tryCatchError") == C_NULL
+        msg = "R library $libR appears to be too old. RCall.jl requires R 3.4.0 or later."
+        if raise
+            error(msg)
+        else
+            info(msg)
+            return false
+        end
+    end
+    Libdl.dlclose(libptr)
+    return true
+end
+
+function locate_libR(Rhome, raise=true)
+    @static if Compat.Sys.iswindows()
+        libR = joinpath(Rhome, "bin", Sys.WORD_SIZE==64 ? "x64" : "i386", "R.dll")
+    else
+        libR = joinpath(Rhome, "lib", "libR.$(Libdl.dlext)")
+    end
+    return validate_libR(libR, raise) ? libR : ""
+end

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -18,7 +18,7 @@ in order.
   [R home directory](https://stat.ethz.ch/R-manual/R-devel/library/base/html/Rhome.html).
 * Otherwise, it runs the `R HOME` command, assuming `R` is located in your [`PATH`](https://en.wikipedia.org/wiki/PATH_(variable)).
 * Otherwise, on Windows, it looks in the [Windows registry](https://cran.r-project.org/bin/windows/base/rw-FAQ.html#Does-R-use-the-Registry_003f).
-* Otherwise, it installs the [`r-base` conda-forge package](https://anaconda.org/conda-forge/r-base).
+* Otherwise, it installs the [`r-base` package](https://anaconda.org/r/r-base).
 
 To change which R installation is used for RCall, set the `R_HOME` environment variable
 and run `Pkg.build("RCall")`.   Once this is configured, RCall remembers the location

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,15 +1,49 @@
 # Installing RCall.jl
 
-RCall.jl requires that a recent version of R, at least 3.4.0, be installed. 
-
-## Standard installations
-
-If R has been installed using one of the standard approaches below, then RCall.jl can simply be installed with
+RCall.jl can simply be installed with
 ```julia
 Pkg.add("RCall")
 ```
+
+RCall.jl will automatically install R for you using [Conda](https://github.com/JuliaPy/Conda.jl)
+if it doesn't detect that you have R 3.4.0 or later installed already.
+
+## Customizing the R installation
+
+Before installing its own copy of R, the RCall build script (run by `Pkg.add`)
+will check for an existing R installation by looking in the following locations,
+in order.
+
+* The `R_HOME` environment variable, if set, should be the location of the
+  [R home directory](https://stat.ethz.ch/R-manual/R-devel/library/base/html/Rhome.html).
+* Otherwise, it runs the `R HOME` command, assuming `R` is located in your [`PATH`](https://en.wikipedia.org/wiki/PATH_(variable)).
+* Otherwise, on Windows, it looks in the [Windows registry](https://cran.r-project.org/bin/windows/base/rw-FAQ.html#Does-R-use-the-Registry_003f).
+* Otherwise, it installs the [`r-base` conda-forge package](https://anaconda.org/conda-forge/r-base).
+
+To change which R installation is used for RCall, set the `R_HOME` environment variable
+and run `Pkg.build("RCall")`.   Once this is configured, RCall remembers the location
+of R in future updates, so you don't need to set `R_HOME` permanently.
+
+You can set `R_HOME` to the empty string `""` to force `Pkg.build` to re-run the
+`R HOME` command, e.g. if you change your PATH:
+```julia
+ENV["R_HOME"]=""
+ENV["PATH"]="....directory of R executable..."
+Pkg.build("RCall")
+```
+
+You can also set `R_HOME` to `"*"` (or any invalid path) to force RCall to use
+its own Conda installation of R:
+```julia
+ENV["R_HOME"]="*"
+Pkg.build("RCall") # will install R via Conda
+```
+
 Should you experience problems with any of these methods, please [open an issue](https://github.com/JuliaStats/RCall.jl/issues/new).
 
+## Standard installations
+
+If you want to install R yourself, rather than relying on the automatic Conda installation, you can use one of the following options:
 
 ### Windows
 The current [Windows binary from CRAN](https://cran.r-project.org/bin/windows/base/).
@@ -28,29 +62,11 @@ The following will update R on recent versions of Ubuntu:
     sudo apt-get update -y
     sudo apt-get install -y r-base r-base-dev
 
+### Other methods
+
+If you have installed R by some other method (e.g. building from scratch, or files copied but not installed in the usual manner), which often happens on cluster installations, then you may need to set `R_HOME` or your `PATH` as described above before running `Pkg.build("RCall")` in order for the build script to find your R installation.
+
 ## Updating R
 
-If you have updated the R installation, you may need to rebuild the RCall cache via
-```julia
-Base.compilecache("RCall")
-```
-     
-## Other methods
-
-If you have installed R by some other method, then some further modifications may be necessary, for example, if you're building R from scratch, or the files have been copied but not installed in the usual manner (common on cluster installations).
-
-Firstly, try setting the `R_HOME` environmental variable to the location of your R installation, which can be found by running `R.home()` from within R. This can be set in your `~/.juliarc.jl` file via the `ENV` global variable, e.g.
-```julia
-ENV["R_HOME"] = ...
-```
-
-You may also need to specify the variable `LD_LIBRARY_PATH` before launching Julia, for example
-```bash
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:`R RHOME`/lib"
-julia
-```
-
-### Windows PATH
-
-The `PATH` environmental variable should contain the location of your R binary, and the `HOME` variable should contain the current user's home directory. These need to be set before Julia is started.
-
+If you have updated your R installation, you may need to re-run `Pkg.build("RCall")`
+as described above, possibly changing the `R_HOME` environment variable first.

--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -33,6 +33,12 @@ export RObject,
    rcopy, rparse, rprint, reval, rcall, rlang,
    rimport, @rimport, @rlibrary, @rput, @rget, @var_str, @R_str
 
+const depfile = joinpath(dirname(@__FILE__),"..","deps","deps.jl")
+if isfile(depfile)
+    include(depfile)
+else
+    error("RCall not properly installed. Please run Pkg.build(\"RCall\")")
+end
 
 include("setup.jl")
 include("types.jl")


### PR DESCRIPTION
This is an alternative to #228.  It is a somewhat more comprehensive change that:

* Moves libR detection to the `Pkg.build` stage.
* Auto-installs R via Conda if it is not found.
* Remembers the libR location on subsequent builds (unless you set the `R_HOME` environment variable to override) so that you only have to configure it correctly once.

One question I had was which Conda channel to use.  There is [r-base in the r channel](https://anaconda.org/r/r-base) and [r-base in the conda-forge channel](https://anaconda.org/conda-forge/r-base).   Right now I'm using ~~conda-forge~~ `r`, but I'm not sure if there is a preference.

close #73