### PR TITLE
update formula copying to StatsModels v0.2.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,6 +6,6 @@ DataArrays 0.7.0
 CategoricalArrays 0.3.0
 AxisArrays 0.0.6
 Compat 0.34.0
-StatsModels 0.2.0
+StatsModels 0.2.4
 Conda
 @windows WinReg 0.2.0

--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -7,7 +7,7 @@ using DataArrays
 using CategoricalArrays
 using DataFrames
 using AxisArrays
-import StatsModels:Formula
+import StatsModels: Formula, @formula
 import DataStructures: OrderedDict
 
 using Compat.Dates

--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -7,7 +7,7 @@ using DataArrays
 using CategoricalArrays
 using DataFrames
 using AxisArrays
-import StatsModels: Formula, @formula
+import StatsModels: Formula, parse!
 import DataStructures: OrderedDict
 
 using Compat.Dates

--- a/src/convert/formula.jl
+++ b/src/convert/formula.jl
@@ -32,7 +32,9 @@ end
 
 function rcopy(::Type{Formula}, l::Ptr{LangSxp})
     ex_orig = rcopy(Expr, l)
-    @eval @formula $ex_orig
+    ex = parse!(copy(ex_orig))
+    lhs, rhs = ex.args[2:3]
+    Formula(ex_orig, ex, lhs, rhs)
 end
 
 

--- a/src/convert/formula.jl
+++ b/src/convert/formula.jl
@@ -31,7 +31,8 @@ function rcopy(::Type{Expr}, l::Ptr{LangSxp})
 end
 
 function rcopy(::Type{Formula}, l::Ptr{LangSxp})
-    Formula(rcopy(l[2]), rcopy(l[3]))
+    ex_orig = rcopy(Expr, l)
+    @eval @formula $ex_orig
 end
 
 
@@ -57,7 +58,7 @@ sexp_formula(n::Number) = sexp(n)
 
 # R formula objects
 function sexp(::Type{LangSxp}, f::Formula)
-    s = protect(rlang_p(:~, sexp_formula(f.lhs), sexp_formula(f.rhs)))
+    s = protect(sexp_formula(f.ex_orig == :() ? f.ex : f.ex_orig))
     try
         setattrib!(s, Const.ClassSymbol, sexp("formula"))
         setattrib!(s, ".Environment", Const.GlobalEnv)


### PR DESCRIPTION
The representation of Formulas has changed in StatsModels.  It now holds onto the whole formula expression (e.g., `Expr(:call, :~, ...)`) as well as the parsed expression and the left- and right-hand sub-expressions.

For copying from R to Julia, it's necessary to invoke the `@formula` model to trigger parsing of the formula expression. (That's not strictly true in this release, since it's just transforming the Expr, but it will be in the future to support things like arbitrary functions in formulae).

For Julia to R, in order to match the old behavior, I propose just copying the Expr of the original (un-parsed) formula (in the `ex_orig` field).  There are some situations (where the Formula is constructed manually from left and right-hand sub expressions) that the `ex_orig` field is an empty expression, but that's deprecated now.  In those cases, this PR pulls the parsed expression in the `ex` field.