### PR TITLE
move AxisArrays out of REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,10 +1,9 @@
 julia 0.7.0-beta2
-Missings 0.2.0
-DataStructures 0.5.0
-DataFrames 0.11.0
 CategoricalArrays 0.3.0
+DataFrames 0.11.0
+DataStructures 0.5.0
+Missings 0.2.0
 Requires 0.5.2
-AxisArrays 0.0.6
 StatsModels 0.2.4
 Conda
 @windows WinReg 0.2.0

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+AxisArrays 0.0.6


### PR DESCRIPTION
I think we should keep DataFrames and CategoricalArrays as direct dependencies as the concepts of factors and data frames are so rooted in R.