### PR TITLE
prefix AxisArrays with .

### DIFF
--- a/src/convert/axisarray.jl
+++ b/src/convert/axisarray.jl
@@ -1,4 +1,4 @@
-using AxisArrays
+using .AxisArrays
 
 function rcopy(::Type{AxisArray}, r::Ptr{S}) where {S<:VectorSxp}
     dnames = getattrib(r, Const.DimNamesSymbol)


### PR DESCRIPTION
This is mentioned in the Requires.jl docs

Fixes #300 (I hope).