### PR TITLE
reinsert `different` info message

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -21,8 +21,9 @@ try
         Rhome = get(ENV, "R_HOME", "")
         if Rhome == "*"
             # install with Conda
-            different = "  To use a different R installation, set the \"R_HOME\" environment variable and re-run Pkg.build(\"RCall\")."
-            @info "Installing R via Conda.$different"
+            @info "Installing R via Conda.  To use a different R installation,"*
+                " set the \"R_HOME\" environment variable and re-run "*
+                "Pkg.build(\"RCall\")."
             Conda.add_channel("r")
             Conda.add("r-base")
             Rhome = joinpath(Conda.LIBDIR, "R")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -21,6 +21,7 @@ try
         Rhome = get(ENV, "R_HOME", "")
         if Rhome == "*"
             # install with Conda
+            different = "  To use a different R installation, set the \"R_HOME\" environment variable and re-run Pkg.build(\"RCall\")."
             @info "Installing R via Conda.$different"
             Conda.add_channel("r")
             Conda.add("r-base")


### PR DESCRIPTION
Hi there, seems like #297 didn't quite get fixed by #299. Unless I'm missing something the variable `different` remains undefined in the revised version. I ran into this problem when trying to install RCall via Conda.