### PR TITLE
Cap StatsModels at 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ DataFrames = "≥ 0.11.0"
 DataStructures = "≥ 0.5.0"
 Missings = "≥ 0.2.0"
 Requires = "≥ 0.5.2"
-StatsModels = "≥ 0.2.4"
+StatsModels = "~0.2.4, 0.3, 0.4, 0.5"
 WinReg = "≥ 0.2.0"
 julia = "1"
 


### PR DESCRIPTION
StatsModels v0.6 is a breaking change: [https://discourse.julialang.org/t/psa-breaking-changes-in-statsmodels-v0-6-0-terms-2-0-son-of-terms/]

I'll also submit a PR to General to add the cap to all older versions as well.