### PR TITLE
Formula transfer updated to StatsModels v0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ deps/deps.jl
 docs/build
 docs/gh-pages
 docs/site
+deps/build.log

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ DataFrames = "≥ 0.11.0"
 DataStructures = "≥ 0.5.0"
 Missings = "≥ 0.2.0"
 Requires = "≥ 0.5.2"
-StatsModels = "≥ 0.5.0"
+StatsModels = "≥ 0.6.0"
 WinReg = "≥ 0.2.0"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RCall"
 uuid = "6f49c342-dc21-5d91-9882-a32aef131414"
-authors = ["Douglas Bates", "Randy Lai", "Simon Byrne <simonbyrne@gmail.com>"]
+authors = ["Douglas Bates <dmbates@gmail.com>", "Randy Lai", "Simon Byrne <simonbyrne@gmail.com>"]
 version = "0.13.2"
 
 [deps]
@@ -24,7 +24,7 @@ DataFrames = "≥ 0.11.0"
 DataStructures = "≥ 0.5.0"
 Missings = "≥ 0.2.0"
 Requires = "≥ 0.5.2"
-StatsModels = "≥ 0.2.4"
+StatsModels = "≥ 0.5.0"
 WinReg = "≥ 0.2.0"
 julia = "1"
 

--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -9,8 +9,9 @@ using REPL
 using Missings
 using CategoricalArrays
 using DataFrames
+using StatsModels
 
-import StatsModels: Formula, parse!
+#import StatsModels: FormulaTerm
 import DataStructures: OrderedDict
 
 import Base: eltype, convert, isascii,

--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -11,7 +11,6 @@ using CategoricalArrays
 using DataFrames
 using StatsModels
 
-#import StatsModels: FormulaTerm
 import DataStructures: OrderedDict
 
 import Base: eltype, convert, isascii,

--- a/src/convert/default.jl
+++ b/src/convert/default.jl
@@ -191,7 +191,7 @@ rcopytype(::Type{RClass{:function}}, s::Ptr{S}) where S<:FunctionSxp = Function
 # LangSxp
 rcopytype(::Type{RClass{:call}}, l::Ptr{LangSxp}) = Expr
 rcopytype(::Type{RClass{Symbol("(")}}, l::Ptr{LangSxp}) = Expr
-rcopytype(::Type{RClass{:formula}}, l::Ptr{LangSxp}) = Formula
+rcopytype(::Type{RClass{:formula}}, l::Ptr{LangSxp}) = FormulaTerm
 
 # Fallback
 rcopytype(::T, s::Ptr{S}) where {T, S<:Sxp} = RObject
@@ -249,7 +249,7 @@ sexpclass(d::AbstractDict) = RClass{:list}
 sexpclass(f::Function) = RClass{:function}
 
 # LangSxp
-sexpclass(f::Formula) = RClass{:formula}
+sexpclass(f::FormulaTerm) = RClass{:formula}
 
 
 # Date

--- a/src/convert/formula.jl
+++ b/src/convert/formula.jl
@@ -36,11 +36,9 @@ function rcopy(::Type{Expr}, l::Ptr{LangSxp})
     f
 end
 
-function rcopy(::Type{Formula}, l::Ptr{LangSxp})
-    ex_orig = rcopy(Expr, l)
-    ex = parse!(copy(ex_orig))
-    lhs, rhs = ex.args[2:3]
-    Formula(ex_orig, ex, lhs, rhs)
+function rcopy(::Type{FormulaTerm}, l::Ptr{LangSxp})
+    expr = rcopy(Expr, l)
+    @eval StatsModels.@formula($expr)
 end
 
 
@@ -65,7 +63,7 @@ sexp_formula(n::Number) = sexp(n)
 
 
 # R formula objects
-function sexp(::Type{RClass{:formula}}, f::Formula)
+function sexp(::Type{RClass{:formula}}, f::FormulaTerm)
     s = protect(sexp_formula(f.ex_orig == :() ? f.ex : f.ex_orig))
     try
         setattrib!(s, Const.ClassSymbol, "formula")

--- a/test/convert/formula.jl
+++ b/test/convert/formula.jl
@@ -14,11 +14,11 @@ using StatsModels
 
 @test rcopy(rcall(Symbol("=="), R"y ~ x + (1 | g)", RObject(@formula y ~ x + (1 | g))))
 @test rcopy(rcall(Symbol("=="), R"y ~ x + (1 | g) + (1 | d)", RObject(@formula y ~ x + (1 | g) + (1 | d))))
-@test_broken rcopy(rcall(Symbol("=="), R"y ~ (a + b) * c", RObject(@formula y ~ (a + b) * c)))
-@test_broken rcopy(rcall(Symbol("=="), R"y ~ c * (a + b)", RObject(@formula y ~ c * (a + b))))
+@test rcopy(rcall(Symbol("=="), R"y ~ a + b + c + a:c + b:c", RObject(@formula y ~ (a + b) * c)))
+@test rcopy(rcall(Symbol("=="), R"y ~ c + a + b + c:a + c:b", RObject(@formula y ~ c * (a + b))))
 
 # testing association
 @test rcopy(rcall(Symbol("=="), R"y ~ a + b + c", RObject(@formula y ~ a + b + c)))
-@test_broken rcopy(rcall(Symbol("=="), R"y ~ a + b * c * d", RObject(@formula y ~ a + b * c * d)))
+@test rcopy(rcall(Symbol("=="), R"y ~ a + b + c + d + b:c + b:d + c:d + b:c:d", RObject(@formula y ~ a + b * c * d)))
 @test rcopy(rcall(Symbol("=="), R"y ~ a : b : c", RObject(@formula y ~ a & b & c)))
 @test rcopy(rcall(Symbol("=="), R"y ~ d + a : b : c", RObject(@formula y ~ d + a & b & c)))

--- a/test/convert/formula.jl
+++ b/test/convert/formula.jl
@@ -1,24 +1,24 @@
 using StatsModels
 
-@test StatsModels.Terms(rcopy(R"y ~ x + (1 | g)")) == StatsModels.Terms(@formula y ~ x + (1 | g))
-@test StatsModels.Terms(rcopy(R"y ~ x + (1 | g) + (1 | d)")) == StatsModels.Terms(@formula y ~ x + (1 | g) + (1 | d))
-@test StatsModels.Terms(rcopy(R"y ~ (a + b) * c")) == StatsModels.Terms(@formula y ~ (a + b) * c)
-@test StatsModels.Terms(rcopy(R"y ~ c : (a + b)")) == StatsModels.Terms(@formula y ~ c & (a + b))
+@test terms(rcopy(R"y ~ x + (1 | g)")) == terms(@formula y ~ x + (1 | g))
+@test terms(rcopy(R"y ~ x + (1 | g) + (1 | d)")) == terms(@formula y ~ x + (1 | g) + (1 | d))
+@test terms(rcopy(R"y ~ (a + b) * c")) == terms(@formula y ~ (a + b) * c)
+@test terms(rcopy(R"y ~ c : (a + b)")) == terms(@formula y ~ c & (a + b))
 
 # testing association
-@test StatsModels.Terms(rcopy(R"y ~ a + b + c")) == StatsModels.Terms(@formula y ~ a + b + c)
-@test StatsModels.Terms(rcopy(R"y ~ a + b * c * d")) == StatsModels.Terms(@formula y ~ a + b * c * d)
-@test StatsModels.Terms(rcopy(R"y ~ a : b : c")) == StatsModels.Terms(@formula y ~ a & b & c)
-@test StatsModels.Terms(rcopy(R"y ~ a + b : c : d")) == StatsModels.Terms(@formula y ~ a + b & c & d)
+@test terms(rcopy(R"y ~ a + b + c")) == terms(@formula y ~ a + b + c)
+@test terms(rcopy(R"y ~ a + b * c * d")) == terms(@formula y ~ a + b * c * d)
+@test terms(rcopy(R"y ~ a : b : c")) == terms(@formula y ~ a & b & c)
+@test terms(rcopy(R"y ~ a + b : c : d")) == terms(@formula y ~ a + b & c & d)
 
 
 @test rcopy(rcall(Symbol("=="), R"y ~ x + (1 | g)", RObject(@formula y ~ x + (1 | g))))
 @test rcopy(rcall(Symbol("=="), R"y ~ x + (1 | g) + (1 | d)", RObject(@formula y ~ x + (1 | g) + (1 | d))))
-@test rcopy(rcall(Symbol("=="), R"y ~ (a + b) * c", RObject(@formula y ~ (a + b) * c)))
-@test rcopy(rcall(Symbol("=="), R"y ~ c * (a + b)", RObject(@formula y ~ c * (a + b))))
+@test_broken rcopy(rcall(Symbol("=="), R"y ~ (a + b) * c", RObject(@formula y ~ (a + b) * c)))
+@test_broken rcopy(rcall(Symbol("=="), R"y ~ c * (a + b)", RObject(@formula y ~ c * (a + b))))
 
 # testing association
 @test rcopy(rcall(Symbol("=="), R"y ~ a + b + c", RObject(@formula y ~ a + b + c)))
-@test rcopy(rcall(Symbol("=="), R"y ~ a + b * c * d", RObject(@formula y ~ a + b * c * d)))
+@test_broken rcopy(rcall(Symbol("=="), R"y ~ a + b * c * d", RObject(@formula y ~ a + b * c * d)))
 @test rcopy(rcall(Symbol("=="), R"y ~ a : b : c", RObject(@formula y ~ a & b & c)))
 @test rcopy(rcall(Symbol("=="), R"y ~ d + a : b : c", RObject(@formula y ~ d + a & b & c)))


### PR DESCRIPTION
Currently some of the tests are broken because the `StatsModels.@formula` macro does not preserve the original expression passed to it.  The test could be changed to compare, e.g.
```
RObject(@formula y ~ (a + b) * c)
```
to
```
R"y ~ a + b + c + a:b + b:c"
```
which would look a little peculiar or, my preferred solution, create an `exorig` field in a `FormulaTerm` like that in a `FunctionTerm`.  @kleinschmidt prefers not to do that.  See discussion in #306 