### PR TITLE
use --no-restore flag when initializing R

### DIFF
--- a/src/setup.jl
+++ b/src/setup.jl
@@ -78,7 +78,7 @@ function initEmbeddedR()
             ccall(:_wputenv,Cint,(Cwstring,),"HOME="*homedir())
         end
 
-        argv = ["REmbeddedJulia","--silent","--no-save"]
+        argv = ["REmbeddedJulia","--silent","--no-save", "--no-restore"]
         ccall((:Rf_initialize_R,libR),Cint,(Cint,Ptr{Ptr{Cchar}}),length(argv),argv)
 
         rs = RStart()
@@ -105,7 +105,7 @@ function initEmbeddedR()
         ENV["R_SHARE_DIR"] = joinpath(Rhome,"share")
 
         # initialize library
-        argv = ["REmbeddedJulia","--silent","--no-save"]
+        argv = ["REmbeddedJulia","--silent","--no-save", "--no-restore"]
         ccall((:Rf_initialize_R,libR),Cint,(Cint,Ptr{Ptr{Cchar}}),length(argv),argv)
 
         ptr_write_console_ex = @cfunction($write_console_ex,Nothing,(Ptr{UInt8},Cint,Cint)).ptr


### PR DESCRIPTION
Currently, when a .RData file is present in the working directory when RCall is initialized, the RData file is loaded into the R session. This is counterintuitive and can lead to extremely high memory consumption. This patch disables this behavior.

I have only tested it on Linux. As far as I understand, RStart.RestoreAction=0 corresponds to --no-restore, so this behavior was already the default on Windows (enforced by R_SetParams in setup.jl:97)