### PR TITLE
Improve conversion from CategoricalArray to factor

### DIFF
--- a/src/convert/categorical.jl
+++ b/src/convert/categorical.jl
@@ -23,10 +23,10 @@ function sexp(::Type{RClass{:factor}}, v::CategoricalArray)
             end
         end
         # due to a bug of CategoricalArrays, we use index(v.pool) instead of index(v)
-        setattrib!(rv, Const.LevelsSymbol, CategoricalArrays.index(v.pool))
+        setattrib!(rv, Const.LevelsSymbol, string.(CategoricalArrays.index(v.pool)))
         setattrib!(rv, Const.ClassSymbol, "factor")
         if CategoricalArrays.isordered(v)
-            rv = rcall(:ordered, rv, CategoricalArrays.levels(v))
+            rv = rcall(:ordered, rv, string.(CategoricalArrays.levels(v)))
         end
     finally
         unprotect(1)


### PR DESCRIPTION
Currently, only `CategoricalArray{String}` are converted to `factor` correctly. This doesn't work on `master`, but works with this PR.

`CategoricalArray{<:Number}`:
```julia
df_symbol = DataFrame(x = randn(100), y=randn(100), z1=rand([:a; :b], 100), z2=rand([:darkorange; :lightblue], 100))

categorical!(df_symbol, :x)
R"str($df_symbol)" # before: error, after: works as expected
```

`CategoricalArray{Symbol}`:
```julia
df_symbol = DataFrame(x = randn(100), y=randn(100), z1=rand([:a; :b], 100), z2=rand([:darkorange; :lightblue], 100))
ggplot(df_symbol) + geom_point(aes(x=:x, y=:y, color=:z1)) # doesn't work
ggplot(df_symbol) + geom_point(aes(x=:x, y=:y, color=:z2)) # uses colors "darkred" and "lightblue"
categorical!(df_symbol, :z2)
ggplot(df_symbol) + geom_point(aes(x=:x, y=:y, color=:z2)) # before: error - after: uses standard colors
```

The caveat is, that now a vector of `Symbol`s behaves quite differently if it's a `CategoricalVector`. (In this example above the colors change.)


This solves half of #331.