### PR TITLE
Fix ordering of factor levels

### DIFF
--- a/src/convert/categorical.jl
+++ b/src/convert/categorical.jl
@@ -16,7 +16,7 @@ end
 
 function sexp(::Type{RClass{:factor}}, v::CategoricalArray)
     rv = protect(sexp(RClass{:integer}, v.refs))
-    order = CategoricalArrays.order(x.pool)
+    order = CategoricalArrays.order(v.pool)
     @inbounds for (i,ref) = enumerate(v.refs)
         if ref == 0
             rv[i] = naeltype(IntSxp)

--- a/src/convert/categorical.jl
+++ b/src/convert/categorical.jl
@@ -16,17 +16,20 @@ end
 
 function sexp(::Type{RClass{:factor}}, v::CategoricalArray)
     rv = protect(sexp(RClass{:integer}, v.refs))
-    try
-        for (i,ref) = enumerate(v.refs)
-            if ref == 0
-                rv[i] = naeltype(IntSxp)
-            end
+    order = CategoricalArrays.order(x.pool)
+    @inbounds for (i,ref) = enumerate(v.refs)
+        if ref == 0
+            rv[i] = naeltype(IntSxp)
+        else
+            rv[i] = order[ref]
         end
-        # due to a bug of CategoricalArrays, we use index(v.pool) instead of index(v)
-        setattrib!(rv, Const.LevelsSymbol, CategoricalArrays.index(v.pool))
-        setattrib!(rv, Const.ClassSymbol, "factor")
+    end
+    try
+        setattrib!(rv, Const.LevelsSymbol, CategoricalArrays.levels(v))
         if CategoricalArrays.isordered(v)
-            rv = rcall(:ordered, rv, CategoricalArrays.levels(v))
+            setattrib!(rv, Const.ClassSymbol, "factor")
+        else
+            setattrib!(rv, Const.ClassSymbol, ["ordered", "factor"])
         end
     finally
         unprotect(1)

--- a/test/convert/categorical.jl
+++ b/test/convert/categorical.jl
@@ -1,18 +1,18 @@
 using CategoricalArrays
 
 # CategoricalArrays
-v = CategoricalArray(repeat(["a", "b"], inner = 5))
+v = CategoricalArray(repeat(["b", "a"], inner = 5))
 @test isequal(rcopy(CategoricalArray,RObject(v)), v)
-v = CategoricalArray(repeat(["a", "b"], inner = 5), ordered=true)
+v = CategoricalArray(repeat(["b", "a"], inner = 5), ordered=true)
 @test isequal(rcopy(CategoricalArray,RObject(v)), v)
-@test CategoricalArrays.levels(rcopy(CategoricalArray,R"factor(c('a','a','c'))")) == ["a","c"]
-@test CategoricalArrays.isordered(rcopy(CategoricalArray,R"ordered(c('a','a','c'))"))
+@test CategoricalArrays.levels(rcopy(CategoricalArray,R"factor(c('c','a','a'))")) == ["a","c"]
+@test CategoricalArrays.isordered(rcopy(CategoricalArray,R"ordered(c('c','a','a'))"))
 
-a = Array{Union{String, Missing}}(repeat(["a", "b"], inner = 5))
+a = Array{Union{String, Missing}}(repeat(["b", "a"], inner = 5))
 a[repeat([true, false], outer = 5)] .= missing
 v = CategoricalArray(a)
 @test isequal(rcopy(CategoricalArray,RObject(v)), v)
 v = CategoricalArray(a, ordered=true)
 @test isequal(rcopy(CategoricalArray,RObject(v)), v)
-@test CategoricalArrays.levels(rcopy(CategoricalArray,R"factor(c('a',NA,'c'))")) == ["a","c"]
-@test CategoricalArrays.isordered(rcopy(CategoricalArray,R"ordered(c('a',NA,'c'))"))
+@test CategoricalArrays.levels(rcopy(CategoricalArray,R"factor(c('c',NA,'a'))")) == ["a","c"]
+@test CategoricalArrays.isordered(rcopy(CategoricalArray,R"ordered(c('c',NA,'a'))"))


### PR DESCRIPTION
The order of levels in the `refs` field of `CategoricalArray` doesn't necessarily reflect the order of `levels`.