### PR TITLE
Fix conversion of CategoricalArray to factor vs. ordered

### DIFF
--- a/src/convert/categorical.jl
+++ b/src/convert/categorical.jl
@@ -27,9 +27,9 @@ function sexp(::Type{RClass{:factor}}, v::CategoricalArray)
     try
         setattrib!(rv, Const.LevelsSymbol, string.(CategoricalArrays.levels(v)))
         if CategoricalArrays.isordered(v)
-            setattrib!(rv, Const.ClassSymbol, "factor")
-        else
             setattrib!(rv, Const.ClassSymbol, ["ordered", "factor"])
+        else
+            setattrib!(rv, Const.ClassSymbol, "factor")
         end
     finally
         unprotect(1)

--- a/test/convert/categorical.jl
+++ b/test/convert/categorical.jl
@@ -21,7 +21,7 @@ for ord in (true, false)
     @test isequal(v2, v)
     @test v2 isa CategoricalVector{Union{String,Missing}}
     @test levels(v2) == levels(v)
-    v = CategoricalArray(a, ordered=true)
+    @test isordered(v2) === ord
 end
 @test levels(rcopy(CategoricalArray, R"factor(c('c',NA,'a'))")) == ["a","c"]
 @test !isordered(rcopy(CategoricalArray, R"factor(c('c',NA,'a'))"))

--- a/test/convert/categorical.jl
+++ b/test/convert/categorical.jl
@@ -1,18 +1,28 @@
 using CategoricalArrays
 
 # CategoricalArrays
-v = CategoricalArray(repeat(["b", "a"], inner = 5))
-@test isequal(rcopy(CategoricalArray,RObject(v)), v)
-v = CategoricalArray(repeat(["b", "a"], inner = 5), ordered=true)
-@test isequal(rcopy(CategoricalArray,RObject(v)), v)
-@test CategoricalArrays.levels(rcopy(CategoricalArray,R"factor(c('c','a','a'))")) == ["a","c"]
-@test CategoricalArrays.isordered(rcopy(CategoricalArray,R"ordered(c('c','a','a'))"))
+for ord in (true, false)
+    v = CategoricalArray(repeat(["b", "a"], inner = 5), ordered=ord)
+    v2 = rcopy(CategoricalArray, RObject(v))
+    @test isequal(v2, v)
+    @test v2 isa CategoricalVector{String}
+    @test levels(v2) == levels(v)
+    @test isordered(v2) === ord
+end
+@test levels(rcopy(CategoricalArray, R"factor(c('c','a','a'))")) == ["a","c"]
+@test !isordered(rcopy(CategoricalArray, R"factor(c('c','a','a'))"))
+@test isordered(rcopy(CategoricalArray, R"ordered(c('c','a','a'))"))
 
 a = Array{Union{String, Missing}}(repeat(["b", "a"], inner = 5))
 a[repeat([true, false], outer = 5)] .= missing
-v = CategoricalArray(a)
-@test isequal(rcopy(CategoricalArray,RObject(v)), v)
-v = CategoricalArray(a, ordered=true)
-@test isequal(rcopy(CategoricalArray,RObject(v)), v)
-@test CategoricalArrays.levels(rcopy(CategoricalArray,R"factor(c('c',NA,'a'))")) == ["a","c"]
-@test CategoricalArrays.isordered(rcopy(CategoricalArray,R"ordered(c('c',NA,'a'))"))
+for ord in (true, false)
+    v = CategoricalArray(a, ordered=ord)
+    v2 = rcopy(CategoricalArray, RObject(v))
+    @test isequal(v2, v)
+    @test v2 isa CategoricalVector{Union{String,Missing}}
+    @test levels(v2) == levels(v)
+    v = CategoricalArray(a, ordered=true)
+end
+@test levels(rcopy(CategoricalArray, R"factor(c('c',NA,'a'))")) == ["a","c"]
+@test !isordered(rcopy(CategoricalArray, R"factor(c('c',NA,'a'))"))
+@test isordered(rcopy(CategoricalArray, R"ordered(c('c',NA,'a'))"))


### PR DESCRIPTION
Ordered and unordered factors were swapped. Add tests to catch this.

Bug introduced by https://github.com/JuliaInterop/RCall.jl/pull/338.