### PR TITLE
Also search for Rhome in HKEY_CURRENT_USER since it's used when users don't have admin rights.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -39,6 +39,10 @@ try
                     try Rhome = WinReg.querykey(WinReg.HKEY_LOCAL_MACHINE,
                                                 "Software\\R-Core\\R", "InstallPath"); catch; end
                 end
+                if isempty(Rhome)
+                    try Rhome = WinReg.querykey(WinReg.HKEY_CURRENT_USER,
+                                                "Software\\R-Core\\R", "InstallPath"); catch; end
+                end
             else
                 if !isdir(Rhome)
                     error("R_HOME is not a directory.")


### PR DESCRIPTION
See https://cran.r-project.org/bin/windows/base/rw-FAQ.html#Does-R-use-the-Registry_003f. It would be great if someone with a Windows machine with a non-admin account and R installed could check if
```julia
WinReg.querykey(WinReg.HKEY_CURRENT_USER,
                                                "Software\\R-Core\\R", "InstallPath")
```
returns the installation path.