### PR TITLE
Fix installation link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
  
 #### Installation
 
-[Installation](http://juliainterop.github.io/RCall.jl/stable/installation.html)
+[Installation](http://juliainterop.github.io/RCall.jl/stable/installation)
 
 #### Getting Started
 


### PR DESCRIPTION
The installation link in the readme seems broken currently; this updated link (no `.html`) seems to work.