### PR TITLE
add methods for an entire column of missing

### DIFF
--- a/src/convert/default.jl
+++ b/src/convert/default.jl
@@ -239,6 +239,11 @@ for (J, C) in ((:Integer,:integer),
     end
 end
 
+# Fallback: entire column of missing to NA
+# R assigns these to logical by default, although if it's all missing, it doesn't matter much
+sexpclass(v::Missing) = RClass{:logical}
+sexpclass(a::AbstractArray{Missing}) = RClass{:logical}
+
 # Fallback: convert AbstractArray to VecSxp (R list)
 sexpclass(a::AbstractArray) = RClass{:list}
 

--- a/test/convert/dataframe.jl
+++ b/test/convert/dataframe.jl
@@ -24,3 +24,12 @@ df = R"""data.frame(dates = as.Date(c("2017-04-14", "2014-04-17")))"""
 R"a = data.frame(a1 = rep(1,3)); a$a2 = matrix(2,3,1)"
 R"b = data.frame(a1 = rep(1,3)); b$a2 = rep(2,3)"
 @test rcopy(R"a") == rcopy(R"b")
+
+# issue 355
+R"naframe = data.frame(x=rep(NA,10))"
+@test all(ismissing.(rcopy(R"db")[!,:x]))
+@test typeof(rcopy(R"db")[!,:x]) == Array{Union{Missing, Bool},1}
+db = DataFrame(x = [missing,missing,missing]);
+db = RObject(db);
+@test rcopy(R"class($(db)[,1])") == "logical"
+

--- a/test/convert/dataframe.jl
+++ b/test/convert/dataframe.jl
@@ -26,9 +26,6 @@ R"b = data.frame(a1 = rep(1,3)); b$a2 = rep(2,3)"
 @test rcopy(R"a") == rcopy(R"b")
 
 # issue 355
-R"naframe = data.frame(x=rep(NA,10))"
-@test all(ismissing.(rcopy(R"db")[!,:x]))
-@test typeof(rcopy(R"db")[!,:x]) == Array{Union{Missing, Bool},1}
 db = DataFrame(x = [missing,missing,missing]);
 db = RObject(db);
 @test rcopy(R"class($(db)[,1])") == "logical"


### PR DESCRIPTION
Closes #355 

`NA` defaulting to `logical` in R seems weird, but R seems to largely think of this as three-value logic instead of an Option/Union type.:

```R
R> class(NA)
[1] "logical"
```