### PR TITLE
Fix and test the Conda-provided R

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,31 +4,39 @@ os:
   - linux
   - osx
 julia:
-  - 1.0
-  - 1.1
-  - 1.2
-  - 1.3
-  - 1.4
-  - nightly
+  - '1.0'
+  - '1' # automatically expands to the latest stable 1.x release
+  - 'nightly'
+
+env:
+  jobs:
+    - USE_CONDA=true
+    - USE_CONDA=false
 
 notifications:
   email: false
 
 before_install:
   # linux
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo add-apt-repository -y "deb http://cran.rstudio.com/bin/linux/ubuntu $(lsb_release -s -c)/"; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update -qq -y; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install --allow-unauthenticated git r-base r-base-dev r-recommended -y; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$USE_CONDA" == "false" ]; then sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$USE_CONDA" == "false" ]; then sudo add-apt-repository -y "deb http://cran.rstudio.com/bin/linux/ubuntu $(lsb_release -s -c)/"; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$USE_CONDA" == "false" ]; then sudo apt-get update -qq -y; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$USE_CONDA" == "false" ] ; then sudo apt-get install --allow-unauthenticated git r-base r-base-dev r-recommended -y; fi
 
   # osx
   # faster than using homebrew/science tap
   # but no permalink to release download
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then wget "https://cran.rstudio.com/bin/macosx/$(wget -qO- https://cran.rstudio.com/bin/macosx/ | sed -n 's/.*href="\(R-[^"]*.pkg\)".*/\1/p' | head -n 1)"; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then sudo installer -pkg R-*.pkg -target /; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$USE_CONDA" == "false" ]; then wget "https://cran.rstudio.com/bin/macosx/$(wget -qO- https://cran.rstudio.com/bin/macosx/ | sed -n 's/.*href="\(R-[^"]*.pkg\)".*/\1/p' | head -n 1)"; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$USE_CONDA" == "false" ]; then sudo installer -pkg R-*.pkg -target /; fi
 
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+
+script:
+- if [ "$USE_CONDA" == "true" ]; then export R_HOME="*"; fi
+- julia --code-coverage=user -e 'using Pkg; Base.VERSION < v"1.1" && Pkg.build()'
+- julia --code-coverage=user -e 'using Pkg; Base.VERSION >= v"1.1" && Pkg.build(; verbose = true)'
+- julia --code-coverage=user -e 'using Pkg; Pkg.test(; coverage=true)'
 
 jobs:
   allow_failures:

--- a/test/namespaces.jl
+++ b/test/namespaces.jl
@@ -6,11 +6,21 @@ module NamespaceTests
     using RCall
     using Test
 
-    @rimport MASS
-    @test rcopy(rcall(MASS.ginv, RObject([1 2; 0 4]))) ≈ [1 -0.5; 0 0.25]
-    @rimport MASS as mass
-    @test rcopy(rcall(mass.ginv, RObject([1 2; 0 4]))) ≈ [1 -0.5; 0 0.25]
-    @rlibrary MASS
-    @test rcopy(rcall(ginv, RObject([1 2; 0 4]))) ≈ [1 -0.5; 0 0.25]
+    RCall.R"""
+        has_mass_package = require("MASS")
+    """
+
+    RCall.@rget has_mass_package
+
+    @info "" has_mass_package
+
+    if has_mass_package # these tests will fail if the R "MASS" package is not already installed
+        @rimport MASS
+        @test rcopy(rcall(MASS.ginv, RObject([1 2; 0 4]))) ≈ [1 -0.5; 0 0.25]
+        @rimport MASS as mass
+        @test rcopy(rcall(mass.ginv, RObject([1 2; 0 4]))) ≈ [1 -0.5; 0 0.25]
+        @rlibrary MASS
+        @test rcopy(rcall(ginv, RObject([1 2; 0 4]))) ≈ [1 -0.5; 0 0.25]
+    end
 
 end


### PR DESCRIPTION
Fixes #389 

## Background
1. Currently, Travis CI does not test the Conda-provided R.
2. Currently, the Conda-provided R is broken on both Linux and macOS (#389).

## Summary of this pull request
This pull request fixes and tests the Conda-provided R. Specifically:
1. Build step: When installing R from Conda, require that the version of R is greater than or equal to 3.4.0 AND strictly less than 4.0.0.
2. Build step: Define `RCall.conda_provided_r`, which is `true` if RCall is using the Conda-provided R, and `false` otherwise.
3. Test suite: fix some hard-coded instances of `R` and `Rscript`
4. Test suite: skip  the "namespaces" tests if the R "MASS" package is not installed.
5. Test suite: skip the `R_PPStackTop` test if we are using the Conda-provided R.
6. Travis CI: test both the Conda and non-Conda ways of getting R.
7. Travis CI: make sure that we always test the latest stable 1.x release of Julia
8. Travis CI: don't test on so many versions of Julia. Specifically, test on exactly three versions of Julia: 1.0 (which is currently the LTS), the latest stable 1.x release of Julia, and Julia nightly.