### PR TITLE
Remove a duplicate method definition for `sexpclass(::Missing)`

### DIFF
--- a/src/convert/default.jl
+++ b/src/convert/default.jl
@@ -241,7 +241,6 @@ end
 
 # Fallback: entire column of missing to NA
 # R assigns these to logical by default, although if it's all missing, it doesn't matter much
-sexpclass(v::Missing) = RClass{:logical}
 sexpclass(a::AbstractArray{Missing}) = RClass{:logical}
 
 # Fallback: convert AbstractArray to VecSxp (R list)


### PR DESCRIPTION
See lines 219 and 244 of `src/convert/default.jl`:

https://github.com/JuliaInterop/RCall.jl/blob/43794215e48408c770d5ce1285c125e4d5f413c5/src/convert/default.jl#L219-L219

https://github.com/JuliaInterop/RCall.jl/blob/43794215e48408c770d5ce1285c125e4d5f413c5/src/convert/default.jl#L244-L244

The method definition on line 244 is unnecessary, because the same exact method was already defined on line 219.

This pull request deletes line 244.