### PR TITLE
README: add the official PkgEval badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@
 #### Development version
 * Linux & OSX: [![Travis Build Status](https://travis-ci.org/JuliaInterop/RCall.jl.svg?branch=master)](https://travis-ci.org/JuliaInterop/RCall.jl)
 * Windows: [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/y3kxma63apcig150/branch/master?svg=true)](https://ci.appveyor.com/project/simonbyrne/rcall-jl)
+* PkgEval: [![PkgEval][pkgeval-img]][pkgeval-url]
 * Coverage: [![Coverage Status](https://coveralls.io/repos/github/JuliaInterop/RCall.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaInterop/RCall.jl?branch=master)
+
+[pkgeval-img]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/R/RCall.named.svg
+[pkgeval-url]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/R/RCall.html
+
 
 #### Documentation
 


### PR DESCRIPTION
This PR adds the PkgEval badge to the README. (More details [here](https://github.com/JuliaCI/NanosoldierReports/blob/master/README.md).)

Please note: RCall is currently failing on PkgEval. This should be fixed by https://github.com/JuliaInterop/RCall.jl/pull/390