### PR TITLE
Fix incorrect function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RCall"
 uuid = "6f49c342-dc21-5d91-9882-a32aef131414"
 authors = ["Douglas Bates <dmbates@gmail.com>", "Randy Lai <randy.cs.lai@gmail.com>", "Simon Byrne <simonbyrne@gmail.com>"]
-version = "0.13.8"
+version = "0.13.9"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -19,7 +19,7 @@ try
 
     if !haskey(ENV,"R_HOME") && isdir(DepFile.Rhome) && validate_libR(DepFile.libR)
         Rhome, libR = DepFile.Rhome, DepFile.libR
-        if hasfield(DepFile, :conda_provided_r)
+        if isdefined(DepFile, :conda_provided_r)
             conda_provided_r = DepFile.conda_provided_r
         end
         @info "Using previously configured R at $Rhome with libR in $libR."


### PR DESCRIPTION
On RCall v0.13.8 if `]build RCall` is run a second time it can fail:

```
(@v1.5) pkg> build RCall
   Building Conda → `~/.julia/packages/Conda/3rPhK/deps/build.log`
   Building RCall → `~/.julia/packages/RCall/Xq1xc/deps/build.log`
┌ Error: Error building `RCall`:
│ ERROR: LoadError: MethodError: no method matching hasfield(::Module, ::Symbol)
│ Closest candidates are:
│   hasfield(!Matched::Type{T}, ::Symbol) where T at reflection.jl:187
│ Stacktrace:
│  [1] top-level scope at /Users/jack/.julia/packages/RCall/Xq1xc/deps/build.jl:22
│  [2] include(::String) at ./client.jl:457
│  [3] top-level scope at none:5
│ in expression starting at /Users/jack/.julia/packages/RCall/Xq1xc/deps/build.jl:11
└ @ Pkg.Operations /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.5/Pkg/src/Operations.jl:949
```