### PR TITLE
Use values(x) to access x.data

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -229,7 +229,7 @@ end
 # iterator for PairListSxp
 IteratorSize(x::Pairs{K, V, I, Ptr{S}}) where {K, V, I, S<:PairListSxp} = Base.SizeUnknown()
 IteratorEltype(x::Pairs{K, V, I, Ptr{S}}) where {K, V, I, S<:PairListSxp} = Base.EltypeUnknown()
-@inline iterate(x::Pairs{K, V, I, Ptr{S}}) where {K, V, I, S<:PairListSxp} = iterate(x, x.data)
+@inline iterate(x::Pairs{K, V, I, Ptr{S}}) where {K, V, I, S<:PairListSxp} = iterate(x, values(x))
 @inline function iterate(x::Pairs{K, V, I, Ptr{S}}, state) where {K, V, I, S<:PairListSxp}
     state == sexp(Const.NilValue) && return nothing
     (tag(state), car(state)), cdr(state)
@@ -237,7 +237,7 @@ end
 
 IteratorSize(x::Pairs{K, V, I, RObject{S}}) where {K, V, I, S<:PairListSxp} = Base.SizeUnknown()
 IteratorEltype(x::Pairs{K, V, I, RObject{S}}) where {K, V, I, S<:PairListSxp} = Base.EltypeUnknown()
-@inline iterate(x::Pairs{K, V, I, RObject{S}}) where {K, V, I, S<:PairListSxp} = iterate(x, x.data.p)
+@inline iterate(x::Pairs{K, V, I, RObject{S}}) where {K, V, I, S<:PairListSxp} = iterate(x, values(x).p)
 @inline function iterate(x::Pairs{K, V, I, RObject{S}}, state) where {K, V, I, S<:PairListSxp}
     state == sexp(Const.NilValue) && return nothing
     (RObject(tag(state)), RObject(car(state))), cdr(state)


### PR DESCRIPTION
In Julia 1.7 the following warning is shown when passing dataframes to R:
```julia
┌ Warning: use values(kwargs) and keys(kwargs) instead of kwargs.data and kwargs.itr
│   caller = iterate(x::Base.Pairs{Int64, RCall.ListSxp, Base.OneTo{Int64}, Ptr{RCall.ListSxp}}) at methods.jl:232
└ @ RCall ~/.julia/packages/RCall/iMDW2/src/methods.jl:232
```
This PR implements what is suggested.