### PR TITLE
Allow for dispatching on the R functions

### DIFF
--- a/src/convert/base.jl
+++ b/src/convert/base.jl
@@ -193,7 +193,7 @@ end
 struct RFunction{F}
     f::F
 end
-(::RFunction)(args...) = rcopy(rcall_p(r,args...))
+(rf::RFunction)(args...) = rcopy(rcall_p(rf.f,args...))
         
 # FunctionSxp
 function rcopy(::Type{Function}, s::Ptr{S}) where S<:FunctionSxp

--- a/src/convert/base.jl
+++ b/src/convert/base.jl
@@ -189,15 +189,20 @@ function rcopy(::Type{A}, s::Ptr{VecSxp};
     a
 end
 
-
+# Function wrapper which allows for dispatch
+struct RFunction{F}
+    f::F
+end
+(::RFunction)(args...) = rcopy(rcall_p(r,args...))
+        
 # FunctionSxp
 function rcopy(::Type{Function}, s::Ptr{S}) where S<:FunctionSxp
     # prevent s begin gc'ed
     r = RObject(s)
-    (args...) -> rcopy(rcall_p(r,args...))
+    RFunction(r)
 end
 function rcopy(::Type{Function}, r::RObject{S}) where S<:FunctionSxp
-    (args...) -> rcopy(rcall_p(r,args...))
+    RFunction(r)
 end
 
 # conversion from Base Julia types


### PR DESCRIPTION
In the current setup, RCall returns a closure in Julia, which means it's hard to know in Julia if something is a function from R. This makes it really hard to workaround things that are weird in R, like is seen in https://github.com/SciML/diffeqr/issues/39. This changes it to use a callable struct instead of a closure in order to allow for dispatching.