### PR TITLE
Update CI to latest practices and fix broken test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 name: CI
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 on:
   push:
     branches: [master]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@latest
-      - uses: r-lib/actions/setup-r@latest
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
       - run: echo "LD_LIBRARY_PATH=$(R RHOME)/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         if: matrix.os == 'ubuntu-latest'
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@latest
+      - uses: julia-actions/cache@v1
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,17 +35,8 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: r-lib/actions/setup-r@v2
+      - uses: julia-actions/cache@latest
+      - uses: r-lib/actions/setup-r@latest
       - run: echo "LD_LIBRARY_PATH=$(R RHOME)/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         if: matrix.os == 'ubuntu-latest'
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,11 +18,8 @@ jobs:
         with:
           use-public-rspm: true
       - run: echo "LD_LIBRARY_PATH=$(R RHOME)/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Make docs
-        run: julia --project=docs/ docs/make.jl
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.SSH_KEY }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@latest
       - run: echo "LD_LIBRARY_PATH=$(R RHOME)/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
       - uses: julia-actions/julia-buildpkg@latest
       - name: Install dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: r-lib/actions/setup-r@latest
+            - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
       - run: echo "LD_LIBRARY_PATH=$(R RHOME)/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
       - uses: julia-actions/julia-buildpkg@latest
       - name: Install dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,7 @@
 name: Documentation
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 on:
   push:
     branches:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-            - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
       - run: echo "LD_LIBRARY_PATH=$(R RHOME)/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,6 @@
 name: Documentation
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: docs-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 on:
   push:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,9 +65,5 @@ end
 
 @info "" RCall.conda_provided_r
 
-@info "" rcopy(reval("sessionInfo()"))
-
-@info "" unsafe_load(cglobal((:R_PPStackTop, RCall.libR)))
-
 # make sure we're back where we started
 @test unsafe_load(cglobal((:R_PPStackTop, RCall.libR), Int)) == R_PPSTACKTOP_INITIAL

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
 using RCall
 using Test
 
+# before RCall does anything
+const R_PPSTACKTOP_INITIAL = unsafe_load(cglobal((:R_PPStackTop, RCall.libR), Int))
+@info "" R_PPSTACKTOP_INITIAL
+
 hd = homedir()
 
 if Sys.iswindows()
@@ -65,8 +69,5 @@ end
 
 @info "" unsafe_load(cglobal((:R_PPStackTop, RCall.libR)))
 
-if !Sys.iswindows() # https://github.com/JuliaInterop/RCall.jl/pull/462
-    if !RCall.conda_provided_r # this test will fail for the Conda-provided R
-        @test unsafe_load(cglobal((:R_PPStackTop, RCall.libR), Int)) == 0
-    end
-end
+# make sure we're back where we started
+@test unsafe_load(cglobal((:R_PPStackTop, RCall.libR), Int)) == R_PPSTACKTOP_INITIAL

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,3 +60,11 @@ for t in tests
 end
 
 @info "" RCall.conda_provided_r
+
+@info "" rcopy(reval("sessionInfo()"))
+
+if !Sys.iswindows() # https://github.com/JuliaInterop/RCall.jl/pull/462
+    if !RCall.conda_provided_r # this test will fail for the Conda-provided R
+        @test unsafe_load(cglobal((:R_PPStackTop, RCall.libR), Int)) == 0
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,8 @@ end
 
 @info "" rcopy(reval("sessionInfo()"))
 
+@info "" unsafe_load(cglobal((:R_PPStackTop, RCall.libR)))
+
 if !Sys.iswindows() # https://github.com/JuliaInterop/RCall.jl/pull/462
     if !RCall.conda_provided_r # this test will fail for the Conda-provided R
         @test unsafe_load(cglobal((:R_PPStackTop, RCall.libR), Int)) == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,9 +60,3 @@ for t in tests
 end
 
 @info "" RCall.conda_provided_r
-
-if !Sys.iswindows() # https://github.com/JuliaInterop/RCall.jl/pull/462
-    if !RCall.conda_provided_r # this test will fail for the Conda-provided R
-        @test unsafe_load(cglobal((:R_PPStackTop, RCall.libR), Int)) == 0
-    end
-end


### PR DESCRIPTION
~The latest CI failures all seem related to a single iffy test that was known to be iffy, tested something that isn't in RCall itself, and was already disabled on Windows. xref #462~

~EDIT:~

~Hmmm, I actually might have an idea what's causing that test to fail. Closing this PR until I've investigated further.~


The fix for the broken test was easy -- check the final stack pointer against the initial stack pointer instead of against 0. I suspect 0 isn't the correct value because of a mixture of various things in R, [ASLR](https://en.wikipedia.org/wiki/Address_space_layout_randomization), and Docker images being essentially a FreeBSD jail / chroot on steroids.

closes #470 
@ViralBShah wanna review since you contributed #462 ?