### PR TITLE
fix datetime to character conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
           - nightly
         R:
           - 'release'
-          - '4'
-          - '3'
+          - '4.0'
+          - '3.0'
         os: [ubuntu-latest]
         arch: [x64]
         experimental: [false]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - R ${{ matrix.R }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -19,7 +19,11 @@ jobs:
           - '1.6'
           - '1'
           - nightly
-        os: [ubuntu-latest, windows-latest]
+        R:
+          - 'release'
+          - '4'
+          - '3'
+        os: [ubuntu-latest]
         arch: [x64]
         experimental: [false]
         include:
@@ -28,10 +32,12 @@ jobs:
             arch: x64
             version: 1
             experimental: false
-          # - os: windows-latest
-          #   arch: x64
-          #   version: 1
-          #   experimental: false
+            R: 'release'
+          - os: windows-latest
+            arch: x64
+            version: 1
+            experimental: false
+            R: 'release'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -42,6 +48,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          r-version: ${{ matrix.R }}
       - run: echo "LD_LIBRARY_PATH=$(R RHOME)/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         if: matrix.os == 'ubuntu-latest'
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         R:
           - 'release'
           - '4.0'
-          - '3.0'
+          - '3.4'
         os: [ubuntu-latest]
         arch: [x64]
         experimental: [false]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - '1.6'
           - '1'
           - nightly
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         arch: [x64]
         experimental: [false]
         include:
@@ -28,10 +28,10 @@ jobs:
             arch: x64
             version: 1
             experimental: false
-          - os: windows-latest
-            arch: x64
-            version: 1
-            experimental: false
+          # - os: windows-latest
+          #   arch: x64
+          #   version: 1
+          #   experimental: false
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RCall"
 uuid = "6f49c342-dc21-5d91-9882-a32aef131414"
 authors = ["Douglas Bates <dmbates@gmail.com>", "Randy Lai <randy.cs.lai@gmail.com>", "Simon Byrne <simonbyrne@gmail.com>"]
-version = "0.13.15"
+version = "0.13.16"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/test/convert/datetime.jl
+++ b/test/convert/datetime.jl
@@ -73,7 +73,13 @@ r = RObject(d)
 @test rcopy(r) === d
 @test rcopy(DateTime, r) === d
 @test rcopy(R"as.POSIXct($s, 'UTC', '%Y-%m-%dT%H:%M:%S')") == d
-@test rcopy(R"identical(as.character($d, '%Y-%m-%dT%H:%M:%S'), $s)")
+# previously the second argument to as.character.POSIXt was `format``, now it defaults
+# to `digits`. Using `format` as a named argument gives a deprecation warning
+# this changed in R 4.3.0 but is listed as a bugfix
+# > as.character(<POSIXt>) now behaves more in line with the methods for atomic vectors such as numbers,
+# > and is no longer influenced by options(). Ditto for as.character(<Date>). The as.character() method
+# > gets arguments digits and OutDec with defaults not depending on options(). Use of as.character(*, format = .) now warns.
+@test rcopy(R"identical(format($d, '%Y-%m-%dT%H:%M:%S'), $s)")
 
 
 s = ["2001-01-01T01:01:01", "1111-11-11T11:11:00", "2012-12-12T12:12:12"]
@@ -88,7 +94,7 @@ r = RObject(d)
 @test rcopy(r) == d
 @test rcopy(Array{DateTime}, r) == d
 @test rcopy(R"as.POSIXct($s, 'UTC', '%Y-%m-%dT%H:%M:%S')") == d
-@test rcopy(R"identical(as.character($d, '%Y-%m-%dT%H:%M:%S'), $s)")
+@test rcopy(R"identical(format($d, '%Y-%m-%dT%H:%M:%S'), $s)")
 
 
 # SubArray
@@ -103,7 +109,7 @@ r = RObject(d)
 @test rcopy(r) == d
 @test rcopy(Array{DateTime}, r) == d
 @test rcopy(R"as.POSIXct($s[1:2], 'UTC', '%Y-%m-%dT%H:%M:%S')") == d
-@test rcopy(R"identical(as.character($d, '%Y-%m-%dT%H:%M:%S'), $s[1:2])")
+@test rcopy(R"identical(format($d, '%Y-%m-%dT%H:%M:%S'), $s[1:2])")
 
 
 d = DateTime[]


### PR DESCRIPTION
The `as.character` behavior seems to have been completely removed in R 4.3.