### PR TITLE
Fix complete_line for Julia REPL with tab-completion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RCall"
 uuid = "6f49c342-dc21-5d91-9882-a32aef131414"
 authors = ["Douglas Bates <dmbates@gmail.com>", "Randy Lai <randy.cs.lai@gmail.com>", "Simon Byrne <simonbyrne@gmail.com>"]
-version = "0.13.17"
+version = "0.13.18"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/RPrompt.jl
+++ b/src/RPrompt.jl
@@ -156,7 +156,7 @@ function LineEdit.complete_line(c::RCompletionProvider, s)
         return ret, token, true
     end
 
-    return String[], 0:-1, false
+    return String[], "", false
 end
 
 function create_r_repl(repl, main)


### PR DESCRIPTION
The current nightly Julia REPL asserts the type of LineEdit.complete_line