### PR TITLE
Add support for tuples and better round tripping of named tuples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/build
 docs/gh-pages
 docs/site
 deps/build.log
+lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RCall"
 uuid = "6f49c342-dc21-5d91-9882-a32aef131414"
 authors = ["Douglas Bates <dmbates@gmail.com>", "Randy Lai <randy.cs.lai@gmail.com>", "Simon Byrne <simonbyrne@gmail.com>"]
-version = "0.13.18"
+version = "0.14.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/RCall.jl
+++ b/src/RCall.jl
@@ -46,6 +46,7 @@ include("convert/datetime.jl")
 include("convert/dataframe.jl")
 include("convert/formula.jl")
 include("convert/namedtuple.jl")
+include("convert/tuple.jl")
 
 include("convert/default.jl")
 include("eventloop.jl")

--- a/src/convert/tuple.jl
+++ b/src/convert/tuple.jl
@@ -1,0 +1,36 @@
+function sexp(::Type{RClass{:JuliaTuple}}, t::Tuple)
+    vs = sexp(RClass{:list}, t)
+    # mark this as originating from a tuple
+    # for roundtrippping, which downstream JuliaCall
+    # relies on
+    # because of the way S3 classes work, this doesn't break anything on the R side
+    # and strictly adds more information that we can take advantage of
+    setattrib!(vs, :class, sexp("JuliaTuple"))
+    vs
+end
+
+function sexp(::Type{RClass{:list}}, t::Tuple)
+    n = length(t)
+    vs = protect(allocArray(VecSxp,n))
+    try
+        for (i, v) in enumerate(t)
+            vs[i] = v
+        end
+    finally
+        unprotect(1)
+    end
+    vs
+end
+
+sexpclass(::Tuple) = RClass{:JuliaTuple}  
+
+rcopytype(::Type{RClass{:JuliaTuple}}, x::Ptr{VecSxp}) = Tuple
+
+function rcopy(::Type{T}, s::Ptr{VecSxp}) where {T <: Tuple}
+    protect(s)
+    try
+        T(rcopy(el) for el in s)
+    finally
+        unprotect(1)
+    end
+end

--- a/test/convert/namedtuple.jl
+++ b/test/convert/namedtuple.jl
@@ -11,3 +11,6 @@ r = RObject((a="a", d=1))
 @test_throws ArgumentError rcopy(typeof(nt), r)
 @test_throws ArgumentError rcopy(NamedTuple{(:a,:b,:c)}, r)
 @test (rcopy(NamedTuple{(:a,:d)}, r); true)
+
+@test rcopy(RObject(sexp(RClass{:list}, nt))) isa OrderedDict
+@test rcopy(RObject(nt)) isa typeof(nt) 

--- a/test/convert/tuple.jl
+++ b/test/convert/tuple.jl
@@ -1,0 +1,15 @@
+t = ("a", 1, [1,2])
+r = RObject(t)
+@test r isa RObject{VecSxp}
+@test length(r) == length(t)
+@test rcopy(Tuple, r) == t
+@test rcopy(typeof(t), r) == t
+@test rcopy(r) == t
+@test rcopy(Array, r) == collect(t)
+r[3] = 2.5
+me_test = @test_throws MethodError rcopy(typeof(t), r)
+@test me_test.value.f === convert
+@test me_test.value.args == (Vector{Int64}, 2.5)
+
+@test rcopy(RObject(sexp(RClass{:list}, t))) isa Vector{Any}
+@test rcopy(RObject(t)) isa typeof(t)


### PR DESCRIPTION
[JuliaCall](https://github.com/Non-Contradiction/JuliaCall/blob/c05473bea78a0197c639f7e82ab1c6f2e943e1cc/inst/julia/convert.jl#L7-L11) currently commits some type piracy to provide support for tuples:


```julia
function sexp(x ::Tuple)
    r = sexp(Array{Any}([x...]))
    setattrib!(r, :class, sexp("JuliaTuple"))
    r
end
```

This PR upstreams a more efficient (and memory safe) approach that avoids the type piracy. The type piracy is particularly unfortunate because it breaks [JellyMe4](https://github.com/palday/JellyMe4.jl/issues/72) when used from within JuliaCall. (JuliaCall works by starting Julia and running RCall from the Julia session.)

I also take advantage of the new tuple implementation to simplify the named tuple implementation a bit and potentially make it a bit more efficient.

Finally, I take advantage of R's class-via-attributes system to annotate the lists created from (named) tuples as coming from Julia, which makes it possible to default to constructing (named) tuples, i.e. the original types, when roundtripping them.