### PR TITLE
handle empty input for reval_p

### DIFF
--- a/src/eval.jl
+++ b/src/eval.jl
@@ -111,7 +111,7 @@ Evaluate an R expression array iteratively. If `throw_error` is `false`,
 the error message and warning will be thrown to stderr.
 """
 function reval_p(expr::Ptr{ExprSxp}, env::Ptr{EnvSxp})
-    local val
+    val = nothing
     protect(expr)
     protect(env)
     try
@@ -122,7 +122,7 @@ function reval_p(expr::Ptr{ExprSxp}, env::Ptr{EnvSxp})
         unprotect(2)
     end
     # set .Last.value
-    if env == Const.GlobalEnv.p
+    if val !== nothing && env == Const.GlobalEnv.p
         set_last_value(val)
     end
     val


### PR DESCRIPTION
if nothing is actually given (like an empty string) this now behaves correctly in returning nothing