### PR TITLE
Don't specify `AbstractArray` for column types in DataFrame `rcopy`

### DIFF
--- a/src/convert/dataframe.jl
+++ b/src/convert/dataframe.jl
@@ -12,7 +12,7 @@ function rcopy(::Type{T}, s::Ptr{VecSxp};
     if normalizenames
         vnames = [Symbol(replace(string(v), '.' => '_')) for v in vnames]
     end
-    DataFrame([vec(rcopy(AbstractArray, c)) for c in s], vnames)
+    DataFrame([vec(rcopy(c)) for c in s], vnames)
 end
 
 ## DataFrame to sexp conversion.


### PR DESCRIPTION
This allows other packages to hook into the conversion system when loading R DataFrames.  

My usecase here is to provide seamless interop between R and Julia for `sf` dataframes, so people can take advantage of all of R's tooling without having to re-implement it in Julia.

An example of the use is that by defining `rcopytype` and `rcopy` for `sfc_MULTIPOLYGON`, which is a simple features collection of multipolygons, I can get those geometries converted to the relevant GeoInterface.jl geometry representation for free.