### PR TITLE
bump Julia compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ Preferences = "1"
 Requires = "0.5.2, 1"
 StatsModels = "0.6, 0.7"
 WinReg = "0.2, 0.3, 1"
-julia = "1"
+julia = "1.6"
 
 [extras]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"


### PR DESCRIPTION
There's nothing in RCall itself that's incompatible with Julia 1.0, but the dependencies for testing are not resolvable on 1.0 and we haven't tested on 1.0 in a while.