### PR TITLE
Fix REPL issue on Julia nightly

### DIFF
--- a/src/RPrompt.jl
+++ b/src/RPrompt.jl
@@ -136,7 +136,8 @@ mutable struct RCompletionProvider <: LineEdit.CompletionProvider
     r::REPL.LineEditREPL
 end
 
-if VERSION >= v"1.12.0-DEV.468"  # Julia PR #54311
+# Julia PR #54311 (backported to 1.11) added the `hint` argument
+if v"1.11.0-beta1.46" <= VERSION < v"1.12.0-DEV.0" || VERSION >= v"1.12.0-DEV.468"
     using REPL.REPLCompletions: bslash_completions
 else
     function bslash_completions(string::String, pos::Int, hint::Bool=false)


### PR DESCRIPTION
The `hint` keyword was added to the API of `complete_line`, and a corresponding positional argument was added to `bslash_completions`. This change adds the `hint` keyword to our method of `complete_line` and passes it along to `bslash_completions`, which is defined locally to accept and ignore the `hint` argument for earlier Julia versions.