### PR TITLE
Remove RException showerror method which supresses backtraces

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -54,7 +54,6 @@ end
 
 
 abstract type RException <: Exception end
-showerror(io::IO, e::RException, bt; backtrace=false) = showerror(io ,e)
 
 # status = 2
 struct RParseIncomplete <: RException


### PR DESCRIPTION
This method definition suppresses the stacktrace for all `RException` exceptions. Can we remove this so that it's easier to determine where an error comes from if there are e.g. lots of `revals` or `R_str`s?