### PR TITLE
Fix SET_SYMVALUE removal (broken)

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -586,6 +586,6 @@ getNamespace(str::String) = reval(rlang(RCall.Const.BaseNamespace["getNamespace"
 
 "Set the variable .Last.value to a given value"
 function set_last_value(s::Ptr{S}) where S<:Sxp
-    ccall((:SET_SYMVALUE,libR),Nothing,(Ptr{SymSxp},Ptr{UnknownSxp}),sexp(Const.LastvalueSymbol),s)
+    globalEnv[Symbol(".Last.value")] = RObject(s)
     nothing
 end


### PR DESCRIPTION
This is how far I got trying to fix the removal of `SET_SYMVALUE` in R 4.5. Internally this assignment should do the same thing as the unpublished internal  API `SET_SYMVALUE`, but the test seems to die without a bracktrace so a probably a segfault. I can try to figure it out at some point but need to relearn how. I'm posting my progress here in case there's any obvious advice/fix.