### PR TITLE
Pin most recent R release at 4.4 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - '1'
           - 'nightly'
         R:
-          - 'release'
+          - '4.4'
           - '4.0'
           - '3.4'
         os: [ubuntu-latest]
@@ -30,11 +30,11 @@ jobs:
           - os: macOS-latest
             version: 1
             experimental: false
-            R: 'release'
+            R: '4.4'
           - os: windows-latest
             version: 1
             experimental: false
-            R: 'release'
+            R: '4.4'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
Separating from https://github.com/JuliaInterop/RCall.jl/pull/562