### PR TITLE
use public API `Rf_defineVar` instead of internal `SET_SYMVALUE`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ concurrency:
   cancel-in-progress: true
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - R ${{ matrix.R }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - R ${{ matrix.R }} - ${{ matrix.os }} -${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -20,7 +20,7 @@ jobs:
           - '1'
           - 'nightly'
         R:
-          - '4.4'
+          - 'release'
           - '4.0'
           - '3.4'
         os: [ubuntu-latest]
@@ -30,11 +30,11 @@ jobs:
           - os: macOS-latest
             version: 1
             experimental: false
-            R: '4.4'
+            R: 'release'
           - os: windows-latest
             version: 1
             experimental: false
-            R: '4.4'
+            R: '4.4' # as of writing, R release CI is intractably slow on Windows 
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ concurrency:
 on:
   push:
     branches:
-      - master
+      - main
     tags: '*'
   pull_request:
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RCall"
 uuid = "6f49c342-dc21-5d91-9882-a32aef131414"
 authors = ["Douglas Bates <dmbates@gmail.com>", "Randy Lai <randy.cs.lai@gmail.com>", "Simon Byrne <simonbyrne@gmail.com>"]
-version = "0.14.6"
+version = "0.14.7"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -32,6 +32,7 @@ IJulia = "1.25"
 Logging = "0, 1"
 Preferences = "1"
 StatsModels = "0.6, 0.7"
+TestSetExtensions = "3"
 Weave = "0.10"
 WinReg = "0.2, 0.3, 1"
 julia = "1.10"
@@ -46,7 +47,8 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestSetExtensions = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
 Weave = "44d3d7a6-8a23-5bf8-98c5-b353f8df5ec9"
 
 [targets]
-test = ["Dates", "AxisArrays", "REPL", "Test", "Random", "CondaPkg", "Pkg", "Logging", "IJulia", "Weave"]
+test = ["Dates", "AxisArrays", "REPL", "Test", "Random", "CondaPkg", "Pkg", "Logging", "IJulia", "Weave", "TestSetExtensions"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Docs Development](https://img.shields.io/badge/docs-dev-blue.svg)](http://juliainterop.github.io/RCall.jl/dev)
 
 [![CI status](https://github.com/JuliaInterop/RCall.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/JuliaInterop/RCall.jl/actions/workflows/ci.yml)
-[![Code coverage](https://codecov.io/gh/JuliaInterop/RCall.jl/branch/master/graph/badge.svg?token=8ED5Wdm8W9)](https://codecov.io/gh/JuliaInterop/RCall.jl)
+[![Code coverage](https://codecov.io/gh/JuliaInterop/RCall.jl/branch/main/graph/badge.svg?token=8ED5Wdm8W9)](https://codecov.io/gh/JuliaInterop/RCall.jl)
 
 
 [![DOI](https://zenodo.org/badge/28725415.svg)](https://zenodo.org/doi/10.5281/zenodo.12771368)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ### Building Documentations
 
 [Documenter](https://github.com/JuliaDocs/Documenter.jl) is used to generate
-the documentations automatically. Documentation on master as well as releases
+the documentations automatically. Documentation on main as well as releases
 are automatically deployed to the gh-pages branch.
 
 To view the docs locally, you first need to install Documenter.jl:

--- a/src/convert/base.jl
+++ b/src/convert/base.jl
@@ -194,7 +194,7 @@ struct RFunction{F}
     f::F
 end
 (rf::RFunction)(args...) = rcopy(rcall_p(rf.f,args...))
-        
+
 # FunctionSxp
 function rcopy(::Type{Function}, s::Ptr{S}) where S<:FunctionSxp
     # prevent s begin gc'ed
@@ -240,7 +240,7 @@ for (J, S, C) in ((:Integer, :IntSxp, :integer),
         end
         function sexp(::Type{RClass{$(QuoteNode(C))}}, a::AbstractArray{T}) where T<:$J
             ra = allocArray($S, size(a)...)
-            copyto!(unsafe_vec(ra),a)
+            copyto!(unsafe_vec(ra), a)
             ra
         end
     end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -584,8 +584,17 @@ end
 getNamespace(str::String) = reval(rlang(RCall.Const.BaseNamespace["getNamespace"], str))
 
 
-"Set the variable .Last.value to a given value"
-function set_last_value(s::Ptr{S}) where S<:Sxp
-    ccall((:SET_SYMVALUE,libR),Nothing,(Ptr{SymSxp},Ptr{UnknownSxp}),sexp(Const.LastvalueSymbol),s)
-    nothing
+"""
+    set_last_value(s::Ptr{<:Sxp})
+
+Set the variable `.Last.value` to a given value
+"""
+function set_last_value(s::Ptr{<:Sxp})
+    # we use Rf_defineVar and not Rf_setValue because .Last.value
+    # may not exist in the non-interactive R session that we create.
+    ccall((:Rf_defineVar, libR),
+           Nothing,
+          (Ptr{SymSxp}, Ptr{UnknownSxp}, Ptr{EnvSxp}),
+          sexp(Const.LastvalueSymbol), s, Const.GlobalEnv.p)
+    return nothing
 end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -41,12 +41,19 @@ for (S, J) in ((:LglSxp, "LOGICAL"), (:IntSxp, "INTEGER"),
 end
 
 """
+    unsafe_vec(r::RObject{<:VectorSxp})
+    unsafe_vec(s::Ptr{S})
+
 Represent the contents of a VectorSxp type as a `Vector`.
 
 This does __not__ copy the contents.  If the argument is not named (in R) or
 otherwise protected from R's garbage collection (e.g. by keeping the
 containing RObject in scope) the contents of this vector can be modified or
 could cause a memory error when accessed.
+
+In the special case that the R vector is empty, then an empty vector is
+allocated on the Julia end. This is necessary as of R 4.5 to avoid issues
+with pointer alignment and an optimization for empty vectors on the R end.
 
 The contents are as stored in R.  Missing values (NA's) are represented
 in R by sentinels.  Missing data values in RealSxp and CplxSxp show
@@ -55,10 +62,17 @@ as `-2147483648`, the minimum 32-bit integer value.  Internally a `LglSxp` is
 represented as `Vector{Int32}`.  The convention is that `0` is `false`,
 `-2147483648` is `NA` and all other values represent `true`.
 """
-unsafe_vec(s::Ptr{S}) where S<:VectorSxp = unsafe_wrap(Array, dataptr(s), length(s))
-unsafe_vec(r::RObject{S}) where S<:VectorSxp = unsafe_vec(r.p)
+unsafe_vec(r::RObject{<:VectorSxp}) = unsafe_vec(r.p)
+
+function unsafe_vec(s::Ptr{S}) where S <: VectorSxp
+    length(s) == 0 && return Vector{eltype(S)}(undef, 0)
+    return unsafe_wrap(Array, dataptr(s), length(s))
+end
 
 """
+    unsafe_array(r::RObject{S})
+    unsafe_array(s::Ptr{S})
+
 The same as `unsafe_vec`, except returns an appropriately sized array.
 """
 unsafe_array(s::Ptr{S}) where S<:VectorSxp =  unsafe_wrap(Array, dataptr(s), size(s))

--- a/test/convert/base.jl
+++ b/test/convert/base.jl
@@ -304,6 +304,8 @@ b = RObject(true)
 @test isa(rcopy(Any, R"1"), Float64)
 @test isa(convert(Any, R"1"), RObject)
 
+# empty R vector
+@test rcopy(reval("numeric(0)")) == Float64[]
 
 # s4
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,12 @@
 using RCall
 using Logging
 using Test
+using TestSetExtensions
 
 using DataStructures: OrderedDict
 using RCall: RClass
 
-@testset "installation" begin
+@testset ExtendedTestSet "installation" begin
     include("installation.jl")
 end
 
@@ -41,7 +42,7 @@ println(R"sessionInfo()")
 
 println(R"l10n_info()")
 
-@testset "RCall" begin
+@testset ExtendedTestSet "RCall" begin
 
     # https://github.com/JuliaStats/RCall.jl/issues/68
     @test hd == homedir()


### PR DESCRIPTION
R 4.5 introduced a few changes that break RCall:
- stricter internal vs. external API boundaries, which we felt with our call to `SET_SYMVALUE`
- apparently an optimization to the way empty vectors are stored, which broke our handling of them by messing up pointer alignment (at least on x86-64)

Failures on nightly are unrelated: #565

closes #561 