### PR TITLE
improve hygiene of rimport macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RCall"
 uuid = "6f49c342-dc21-5d91-9882-a32aef131414"
 authors = ["Douglas Bates <dmbates@gmail.com>", "Randy Lai <randy.cs.lai@gmail.com>", "Simon Byrne <simonbyrne@gmail.com>"]
-version = "0.14.7"
+version = "0.14.8"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/namespaces.jl
+++ b/src/namespaces.jl
@@ -112,7 +112,7 @@ using .__temp__
 """
 macro rlibrary(x)
     tmp = gensym("RCall")
-    ex = Expr(:block,
+    ex = Expr(:block, __source__,
               Expr(:(=), esc(tmp), Expr(:call, GlobalRef(@__MODULE__, :rimport), QuoteNode(x))),
               Expr(:using, Expr(:., :., tmp)))
     return Expr(:toplevel, ex)


### PR DESCRIPTION
The previous version included an `eval`. 🤔 