### PR TITLE
fix rlibrary-marcro test on Julia 1.12

### DIFF
--- a/test/namespaces.jl
+++ b/test/namespaces.jl
@@ -17,7 +17,10 @@ module NamespaceTests
         @test rcopy(rcall(MASS.ginv, RObject([1 2; 0 4]))) ≈ [1 -0.5; 0 0.25]
         @rimport MASS as mass
         @test rcopy(rcall(mass.ginv, RObject([1 2; 0 4]))) ≈ [1 -0.5; 0 0.25]
-        @rlibrary MASS
+        # In Julia 1.12+, we need to explicitly call `@eval` to force timeliness / the correct world-age
+        # when using `@rlibrary` within a nested `if` and then immediately depending on the result
+        # of the macro (here: the existence of `ginv`).
+        @eval @rlibrary MASS
         @test rcopy(rcall(ginv, RObject([1 2; 0 4]))) ≈ [1 -0.5; 0 0.25]
     end
 


### PR DESCRIPTION
Julia 1.12 introduced more strict world age semantics for global bindings, which requires the explicit use of a `eval` when using the `rlibrary` macro within a nested scope and then immediately depending on its results.

> [!NOTE]
> This does not fix the REPL issue on 1.12, so tests will still fail on nightly/RC. 