### PR TITLE
Fix BslashCompletion API incompatibility with Julia 1.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
-            TEST_REPL: ${{ matrix.version == 'min' }}
+            TEST_REPL: true
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         version:
           - 'min'
           - '1'
-          - 'nightly'
+          - 'pre'
         R:
           - 'release'
           - '4.0'

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RCall"
 uuid = "6f49c342-dc21-5d91-9882-a32aef131414"
-version = "0.14.12"
+version = "0.14.13"
 authors = ["Douglas Bates <dmbates@gmail.com>", "Randy Lai <randy.cs.lai@gmail.com>", "Simon Byrne <simonbyrne@gmail.com>"]
 
 [deps]

--- a/src/RPrompt.jl
+++ b/src/RPrompt.jl
@@ -144,6 +144,22 @@ else
     end
 end
 
+# Julia 1.12 changed BslashCompletion: renamed field `bslash` -> `completion`, added
+# `name` field, removed `_completion_text` support, and `complete_line_named` now requires
+# the partial string to be `String` (not `SubString`) in the return tuple.
+# Return NamedCompletion objects on Julia 1.12+ to use the new API properly.
+@static if hasfield(REPLCompletions.BslashCompletion, :completion)
+    function _bslash_completions_result(ret, partial, range)
+        completions = LineEdit.NamedCompletion[LineEdit.NamedCompletion(c.completion, c.name)
+                                               for c in ret]
+        return completions, String(partial[range]), true
+    end
+else
+    function _bslash_completions_result(ret, partial, range)
+        return map(REPLCompletions.completion_text, ret), partial[range], true
+    end
+end
+
 function LineEdit.complete_line(c::RCompletionProvider, s; hint::Bool=false)
     buf = s.input_buffer
     partial = String(buf.data[1:(buf.ptr - 1)])
@@ -151,7 +167,7 @@ function LineEdit.complete_line(c::RCompletionProvider, s; hint::Bool=false)
     full = LineEdit.input_string(s)
     ret, range, should_complete = bslash_completions(full, lastindex(partial), hint)[2]
     if length(ret) > 0 && should_complete
-        return map(REPLCompletions.completion_text, ret), partial[range], should_complete
+        return _bslash_completions_result(ret, partial, range)
     end
 
     # complete r

--- a/src/RPrompt.jl
+++ b/src/RPrompt.jl
@@ -249,6 +249,12 @@ end
 
 function repl_init(repl)
     mirepl = isdefined(repl, :mi) ? repl.mi : repl
+    # On Julia 1.13+, active_repl is set before atreplinit hooks fire but
+    # interface is only populated later inside run_frontend. Pre-populate it
+    # here (run_frontend checks isdefined and reuses it if already set).
+    if !isdefined(mirepl, :interface)
+        mirepl.interface = REPL.setup_interface(mirepl)
+    end
     main_mode = mirepl.interface.modes[1]
     r_mode = create_r_repl(mirepl, main_mode)
     push!(mirepl.interface.modes, r_mode)

--- a/src/RPrompt.jl
+++ b/src/RPrompt.jl
@@ -153,10 +153,14 @@ end
         completions = LineEdit.NamedCompletion[LineEdit.NamedCompletion(c.completion,
                                                                         c.name)
                                                for c in ret]
+        # we always return true for the should_complete field because this is only
+        # called after we've checked should_complete
         return completions, String(partial[range]), true
     end
 else
     function _bslash_completions_result(ret, partial, range)
+        # we always return true for the should_complete field because this is only
+        # called after we've checked should_complete
         return map(REPLCompletions.completion_text, ret), partial[range], true
     end
 end

--- a/src/RPrompt.jl
+++ b/src/RPrompt.jl
@@ -150,7 +150,8 @@ end
 # Return NamedCompletion objects on Julia 1.12+ to use the new API properly.
 @static if hasfield(REPLCompletions.BslashCompletion, :completion)
     function _bslash_completions_result(ret, partial, range)
-        completions = LineEdit.NamedCompletion[LineEdit.NamedCompletion(c.completion, c.name)
+        completions = LineEdit.NamedCompletion[LineEdit.NamedCompletion(c.completion,
+                                                                        c.name)
                                                for c in ret]
         return completions, String(partial[range]), true
     end

--- a/src/RPrompt.jl
+++ b/src/RPrompt.jl
@@ -171,6 +171,10 @@ function LineEdit.complete_line(c::RCompletionProvider, s; hint::Bool=false)
         return _bslash_completions_result(ret, partial, range)
     end
 
+    # In Julia 1.12+, hints are generated on a background thread; calling R from there
+    # is not thread-safe and will crash. Skip R completions for hints.
+    hint && return String[], "", false
+
     # complete r
     utils = findNamespace("utils")
     rcall_p(utils[".assignLinebuffer"], partial)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -91,7 +91,10 @@ send_repl("\b", false)
 @test check_repl_stdout("julia> ")
 
 send_repl("x = \"orange\"")
-@test check_repl_stdout("x = \"orange\"")
+# Julia 1.13+ applies syntax highlighting to REPL input, so the literal
+# `x = "orange"` is not present verbatim in the output (the quotes are
+# wrapped in ANSI color codes).  Check for the evaluated result instead.
+@test check_repl_stdout("\"orange\"")
 
 send_repl("\$", false)
 @test check_repl_stdout("R> ")


### PR DESCRIPTION
Julia 1.12 changed the REPL `BslashCompletion` struct:
- Renamed field `bslash` → `completion` and added `name` field
- Removed `_completion_text` method for `BslashCompletion`
- `complete_line_named` now requires `String` (not `SubString`) and accepts `NamedCompletion` objects in the return tuple

The previous code called `map(REPLCompletions.completion_text, ret)` which fails with a MethodError on Julia 1.12, and returned `partial[range]` (a `SubString`) which fails the type assertion in `complete_line_named`.

Fix: use `@static if hasfield(REPLCompletions.BslashCompletion, :completion)` to detect Julia 1.12+ at compile time. On 1.12+, return `NamedCompletion` objects built from `c.completion`/`c.name` and wrap the range slice in `String()`. On older Julia, keep the existing behavior.