### PR TITLE
Fix thread-unsafe R calls during hint generation on Julia 1.12+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
-            TEST_REPL: ${{ matrix.version == 'min' }}
+            TEST_REPL: true
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         version:
           - 'min'
           - '1'
-          - 'nightly'
+          - 'pre'
         R:
           - 'release'
           - '4.0'

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Actions Repository
         uses: actions/checkout@v6
       - name: Check spelling
-        uses: crate-ci/typos@78bc6fb2c0d734235d57a2d6b9de923cc325ebdd # v1.43.4
+        uses: crate-ci/typos@631208b7aac2daa8b707f55e7331f9112b0e062d # v1.44.0
         with:
             config: _typos.toml
             write_changes: true

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RCall"
 uuid = "6f49c342-dc21-5d91-9882-a32aef131414"
-authors = ["Douglas Bates <dmbates@gmail.com>", "Randy Lai <randy.cs.lai@gmail.com>", "Simon Byrne <simonbyrne@gmail.com>"]
 version = "0.14.12"
+authors = ["Douglas Bates <dmbates@gmail.com>", "Randy Lai <randy.cs.lai@gmail.com>", "Simon Byrne <simonbyrne@gmail.com>"]
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
@@ -32,7 +32,7 @@ IJulia = "1.25"
 Logging = "0, 1"
 Preferences = "1"
 StatsModels = "0.6, 0.7"
-TestSetExtensions = "3"
+TestSetExtensions = "3, 4"
 Weave = "0.10"
 WinReg = "0.2, 0.3, 1"
 julia = "1.10"

--- a/src/RPrompt.jl
+++ b/src/RPrompt.jl
@@ -249,6 +249,12 @@ end
 
 function repl_init(repl)
     mirepl = isdefined(repl, :mi) ? repl.mi : repl
+    # On Julia 1.13+, active_repl is set before atreplinit hooks fire but
+    # interface is only populated later inside run_frontend. Pre-populate it
+    # here (run_frontend checks isdefined and reuses it if already set).
+    if !isdefined(mirepl, :interface)
+        mirepl.interface = REPL.setup_interface(mirepl)
+    end
     main_mode = mirepl.interface.modes[1]
     r_mode = create_r_repl(mirepl, main_mode)
     push!(mirepl.interface.modes, r_mode)

--- a/src/RPrompt.jl
+++ b/src/RPrompt.jl
@@ -153,10 +153,14 @@ end
         completions = LineEdit.NamedCompletion[LineEdit.NamedCompletion(c.completion,
                                                                         c.name)
                                                for c in ret]
+        # we always return true for the should_complete field because this is only
+        # called after we've checked should_complete
         return completions, String(partial[range]), true
     end
 else
     function _bslash_completions_result(ret, partial, range)
+        # we always return true for the should_complete field because this is only
+        # called after we've checked should_complete
         return map(REPLCompletions.completion_text, ret), partial[range], true
     end
 end

--- a/src/RPrompt.jl
+++ b/src/RPrompt.jl
@@ -171,6 +171,10 @@ function LineEdit.complete_line(c::RCompletionProvider, s; hint::Bool=false)
         return _bslash_completions_result(ret, partial, range)
     end
 
+    # In Julia 1.12+, hints are generated on a background thread; calling R from there
+    # is not thread-safe and will crash. Skip R completions for hints.
+    hint && return String[], "", false
+
     # complete r
     utils = findNamespace("utils")
     rcall_p(utils[".assignLinebuffer"], partial)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -91,7 +91,10 @@ send_repl("\b", false)
 @test check_repl_stdout("julia> ")
 
 send_repl("x = \"orange\"")
-@test check_repl_stdout("x = \"orange\"")
+# Julia 1.13+ applies syntax highlighting to REPL input, so the literal
+# `x = "orange"` is not present verbatim in the output (the quotes are
+# wrapped in ANSI color codes).  Check for the evaluated result instead.
+@test check_repl_stdout("\"orange\"")
 
 send_repl("\$", false)
 @test check_repl_stdout("R> ")


### PR DESCRIPTION
Fix thread-unsafe R calls during hint generation on Julia 1.12+

Julia 1.12 added hint generation that calls `complete_line` from a background thread (`Threads.@spawn` in `check_show_hint`). Calling R functions from that thread while R is in use on the main thread causes a crash.

Skip R completions when `hint=true`; bslash/latex completions (pure Julia) still work for hints, and R completions run normally during actual Tab completion on the main thread.