### PR TITLE
zizmor GHA audit

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.SSH_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - R ${{ matrix.R }} - ${{ matrix.os }} -${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
@@ -35,23 +37,25 @@ jobs:
             experimental: false
             R: 'release'
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v3
-      - uses: r-lib/actions/setup-r@v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3
+      - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2
         with:
           use-public-rspm: true
           r-version: ${{ matrix.R }}
       - run: echo "LD_LIBRARY_PATH=$(R RHOME)/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         if: matrix.os == 'ubuntu-latest'
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1
+      - uses: julia-actions/julia-runtest@d60b785c6f2bdf4ebfb18b2b6f7d93b7dfb0efe3 # v1
         env:
             TEST_REPL: true
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
+      - uses: julia-actions/julia-processcoverage@03114f09f119417c3242a9fb6e0b722676aedf38 # v1
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           file: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,15 +12,20 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      statuses: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: r-lib/actions/setup-r@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2
         with:
           use-public-rspm: true
           r-version: '4.4'
       - run: echo "LD_LIBRARY_PATH=$(R RHOME)/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-docdeploy@v1
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1
+      - uses: julia-actions/julia-docdeploy@e62cc8fd639797a0c2922a437d5b1b81c4a12787 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.SSH_KEY }}

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,14 +7,19 @@ jobs:
   typos-check:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Check spelling
         uses: crate-ci/typos@631208b7aac2daa8b707f55e7331f9112b0e062d # v1.44.0
         with:
             config: _typos.toml
             write_changes: true
-      - uses: reviewdog/action-suggester@v1
+      - uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
         with:
           tool_name: Typos

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,11 +26,13 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: "1"
-      - uses: julia-actions/cache@v3
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3
       - name: Install JuliaFormatter
         shell: julia --project=@format --color=yes {0}
         run: |

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,28 @@
+---
+name: GitHub Actions Security Analysis with zizmor 🌈
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+permissions: {}
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      # security-events: write  # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read  # Only needed for private repos. Needed to clone the repo.
+      # actions: read  # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e  # v0.5.3
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
| Workflow | Job | Permissions Before | Permissions After | Rationale |
|---|---|---|---|---|
| `ci.yml` | `test` | *(default — overly broad)* | `contents: read` | Read-only: checks out code, runs tests, uploads coverage via its own Codecov token |
| `compat.yml` | `CompatHelper` | *(default — overly broad)* | `contents: write`, `pull-requests: write` | CompatHelper creates branches and opens PRs to update compat bounds |
| `docs.yml` | `build` | *(default — overly broad)* | `contents: write`, `statuses: write` | Deployer pushes to `gh-pages` via SSH key; GITHUB_TOKEN used for commit status updates |
| `spellcheck.yml` | `typos-check` | *(default — overly broad)* | `contents: read`, `pull-requests: write` | Checks out code read-only; reviewdog posts inline PR suggestions |
| `style.yml` | `format-check` | `actions: write`, `contents: read`, `pull-requests: write` | *(unchanged)* | Already explicitly minimal: cache deletion, read repo, post format suggestions |
| `TagBot.yml` | `TagBot` | `contents: write` *(workflow-level)* | *(unchanged)* | Already explicit; `contents: write` sufficient for creating tags/releases via event payload |
| `zizmor.yaml` | `zizmor` | *(new file)* | `contents: read` | New workflow — clones repo for security analysis only |
